### PR TITLE
test(middleware): add integration tests for x402 payment verification

### DIFF
--- a/src/__tests__/middleware/x402.test.ts
+++ b/src/__tests__/middleware/x402.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// x402.ts reads env vars inside the plugin function, so set them before the app registers the plugin.
+// We still need them here for the mock payment address used in test assertions.
+const PAYMENT_ADDRESS = 'GPAYMENTADDRESS123456789012345678901234567890123456789012'
+
+// ── All mock objects via vi.hoisted so they exist when vi.mock factories execute ──
+const {
+  mockVerify,
+  mockSettle,
+  mockInitialize,
+  mockRegisterChain,
+  MockResourceServer,
+  MockFacilitatorClient,
+  MockExactScheme,
+} = vi.hoisted(() => {
+  const mockVerify = vi.fn()
+  const mockSettle = vi.fn().mockResolvedValue(undefined)
+  const mockInitialize = vi.fn().mockResolvedValue(undefined)
+
+  // .register() returns `this` for chaining
+  const instance = {
+    initialize: mockInitialize,
+    verify: mockVerify,
+    settle: mockSettle,
+    register: vi.fn(),
+  }
+  instance.register.mockReturnValue(instance)
+  const mockRegisterChain = instance
+
+  // Constructor mocks — must be regular functions (not arrows) to support `new`
+  function MockResourceServer() { return instance }
+  function MockFacilitatorClient() { return {} }
+  function MockExactScheme() { return {} }
+
+  return { mockVerify, mockSettle, mockInitialize, mockRegisterChain, MockResourceServer, MockFacilitatorClient, MockExactScheme }
+})
+
+vi.mock('@x402/core/server', () => ({
+  x402ResourceServer: MockResourceServer,
+  HTTPFacilitatorClient: MockFacilitatorClient,
+}))
+
+vi.mock('@x402/stellar/exact/server', () => ({
+  ExactStellarScheme: MockExactScheme,
+}))
+
+import Fastify from 'fastify'
+import { registerX402 } from '../../middleware/x402'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+async function buildApp() {
+  process.env.ORACLE_PAYMENT_ADDRESS = PAYMENT_ADDRESS
+  process.env.STELLAR_NETWORK = 'testnet'
+  const app = Fastify({ logger: false })
+  await app.register(registerX402)
+  app.get('/price/test', async () => ({ ok: true }))
+  app.get('/pools/test', async () => ({ ok: true }))
+  app.get('/candles/test', async () => ({ ok: true }))
+  app.get('/public', async () => ({ ok: true }))
+  await app.ready()
+  return app
+}
+
+function makePaymentHeader(overrides: Record<string, unknown> = {}): string {
+  const payload = { scheme: 'exact', amount: '$0.10', recipient: PAYMENT_ADDRESS, ...overrides }
+  return Buffer.from(JSON.stringify(payload)).toString('base64')
+}
+
+beforeEach(() => {
+  mockVerify.mockReset()
+  mockSettle.mockReset().mockResolvedValue(undefined)
+  mockInitialize.mockReset().mockResolvedValue(undefined)
+  mockRegisterChain.register.mockReturnValue(mockRegisterChain)
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('x402 middleware', () => {
+  it('returns 200 when payment header is valid', async () => {
+    mockVerify.mockResolvedValue({ isValid: true })
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/price/test',
+      headers: { 'x-payment': makePaymentHeader() },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(mockVerify).toHaveBeenCalledOnce()
+  })
+
+  it('returns 402 with x402Version and accepts body when payment header is missing', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({ method: 'GET', url: '/price/test' })
+
+    expect(res.statusCode).toBe(402)
+    const body = res.json()
+    expect(body).toHaveProperty('x402Version', 1)
+    expect(body).toHaveProperty('accepts')
+    expect(body.accepts[0]).toHaveProperty('price', '$0.10')
+    expect(body.accepts[0]).toHaveProperty('payTo', PAYMENT_ADDRESS)
+    expect(mockVerify).not.toHaveBeenCalled()
+  })
+
+  it('returns 402 when payment is for wrong amount', async () => {
+    mockVerify.mockResolvedValue({ isValid: false, invalidReason: 'amount mismatch' })
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/price/test',
+      headers: { 'x-payment': makePaymentHeader({ amount: '$0.01' }) },
+    })
+
+    expect(res.statusCode).toBe(402)
+    expect(res.json()).toMatchObject({ error: 'Payment invalid', reason: 'amount mismatch' })
+  })
+
+  it('returns 402 when payment is for wrong recipient', async () => {
+    mockVerify.mockResolvedValue({ isValid: false, invalidReason: 'recipient mismatch' })
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/price/test',
+      headers: { 'x-payment': makePaymentHeader({ recipient: 'GWRONGADDRESS' }) },
+    })
+
+    expect(res.statusCode).toBe(402)
+    expect(res.json()).toMatchObject({ error: 'Payment invalid', reason: 'recipient mismatch' })
+  })
+
+  it('does not gate non-matching routes', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({ method: 'GET', url: '/public' })
+
+    expect(res.statusCode).toBe(200)
+    expect(mockVerify).not.toHaveBeenCalled()
+  })
+
+  it('gates /pools with $0.05 price requirement', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({ method: 'GET', url: '/pools/test' })
+
+    expect(res.statusCode).toBe(402)
+    expect(res.json().accepts[0]).toHaveProperty('price', '$0.05')
+  })
+
+  it('gates /candles with $0.05 price requirement', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({ method: 'GET', url: '/candles/test' })
+
+    expect(res.statusCode).toBe(402)
+    expect(res.json().accepts[0]).toHaveProperty('price', '$0.05')
+  })
+
+  it('settles payment asynchronously after successful verification', async () => {
+    mockVerify.mockResolvedValue({ isValid: true })
+    const app = await buildApp()
+
+    await app.inject({
+      method: 'GET',
+      url: '/price/test',
+      headers: { 'x-payment': makePaymentHeader() },
+    })
+
+    await new Promise(r => setTimeout(r, 20))
+    expect(mockSettle).toHaveBeenCalledOnce()
+  })
+})

--- a/src/middleware/x402.ts
+++ b/src/middleware/x402.ts
@@ -5,14 +5,11 @@ import { x402ResourceServer, HTTPFacilitatorClient } from '@x402/core/server'
 // @ts-ignore
 import { ExactStellarScheme } from '@x402/stellar/exact/server'
 
-const PAYMENT_ADDRESS = process.env.ORACLE_PAYMENT_ADDRESS
-const FACILITATOR_URL = process.env.X402_FACILITATOR_URL ?? 'https://facilitator.stellar.org'
-const NETWORK = (process.env.STELLAR_NETWORK === 'mainnet' ? 'stellar:pubnet' : 'stellar:testnet') as string
-
 // Routes gated by x402 and their prices
 const GATED_ROUTES: Record<string, { price: string; description: string }> = {
   '/price': { price: '$0.10', description: 'Unified SDEX+AMM price with VWAP and best route' },
   '/pools': { price: '$0.05', description: 'AMM liquidity pool reserves and spot prices' },
+  '/candles': { price: '$0.05', description: 'OHLCV candle data for trading charts' },
 }
 
 /**
@@ -20,6 +17,11 @@ const GATED_ROUTES: Record<string, { price: string; description: string }> = {
  * Only active when ORACLE_PAYMENT_ADDRESS is set in env.
  */
 async function x402Plugin(app: FastifyInstance) {
+  // Read at plugin init time (not module load) so tests can inject env vars before app.register()
+  const PAYMENT_ADDRESS = process.env.ORACLE_PAYMENT_ADDRESS
+  const FACILITATOR_URL = process.env.X402_FACILITATOR_URL ?? 'https://facilitator.stellar.org'
+  const NETWORK = (process.env.STELLAR_NETWORK === 'mainnet' ? 'stellar:pubnet' : 'stellar:testnet') as string
+
   if (!PAYMENT_ADDRESS) {
     app.log.warn('[oracle] ORACLE_PAYMENT_ADDRESS not set — x402 gating disabled')
     return
@@ -46,7 +48,7 @@ async function x402Plugin(app: FastifyInstance) {
       scheme: 'exact' as const,
       price,
       network: NETWORK,
-      payTo: PAYMENT_ADDRESS!,
+      payTo: PAYMENT_ADDRESS,
     }
 
     // No payment header — return 402 with requirements

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/__tests__"]
 }


### PR DESCRIPTION
## Summary

- Refactors env var reads (`ORACLE_PAYMENT_ADDRESS`, `STELLAR_NETWORK`) from module level into `x402Plugin` function body so tests can inject environment before `app.register()` is called
- Adds `/candles` to `GATED_ROUTES` at `$0.05`
- Excludes `src/__tests__` from `tsconfig.json` main build
- Creates `src/__tests__/middleware/x402.test.ts` with **8 integration tests**

## Test coverage

| Test | Case |
|---|---|
| Valid payment | 200 returned, `verify` called once |
| Missing payment header | 402 with `x402Version: 1`, `accepts`, `payTo` |
| Wrong amount | 402 with `error: Payment invalid` |
| Wrong recipient | 402 with `error: Payment invalid` |
| Non-gated route | 200, `verify` never called |
| `/pools` gating | 402 with `price: $0.05` |
| `/candles` gating | 402 with `price: $0.05` |
| Async settle | `settle` called once after valid payment |

## How to run

```bash
git checkout test/x402-middleware-tests
npm install
npm test
# → Tests: 8 passed
```

Closes #21