### PR TITLE
feat(api): add POST /pairs endpoint for runtime trading pair management

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,17 @@ model IndexerState {
   @@map("indexer_state")
 }
 
+model PairConfig {
+  pairKey   String   @id @map("pair_key")
+  assetACode   String   @map("asset_a_code")
+  assetAIssuer String?  @map("asset_a_issuer")
+  assetBCode   String   @map("asset_b_code")
+  assetBIssuer String?  @map("asset_b_issuer")
+  addedAt   DateTime @default(now()) @map("added_at")
+
+  @@map("pair_configs")
+}
+
 model Webhook {
   id        String   @id @default(uuid())
   url       String

--- a/src/__tests__/pairs.test.ts
+++ b/src/__tests__/pairs.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Fastify from 'fastify'
+
+// vi.mock factories are hoisted — declare all mock fns with vi.hoisted()
+const { mockHasPair, mockRegisterPair, mockPersistPair, mockGetActivePairs } = vi.hoisted(() => ({
+  mockHasPair: vi.fn(),
+  mockRegisterPair: vi.fn(),
+  mockPersistPair: vi.fn(),
+  mockGetActivePairs: vi.fn(),
+}))
+
+vi.mock('../pairsRegistry', () => ({
+  getActivePairs: mockGetActivePairs,
+  hasPair: mockHasPair,
+  registerPair: mockRegisterPair,
+  persistPair: mockPersistPair,
+  parseAssetStr: (s: string) => {
+    const parts = s.split(':')
+    const code = parts[0]?.toUpperCase()
+    if (!code) return null
+    const issuer = parts[1] && parts[1].toLowerCase() !== 'native' ? parts[1] : null
+    if (issuer && !/^G[A-Z2-7]{55}$/.test(issuer)) return null
+    return { code, issuer }
+  },
+  makePairKey: (a: any, b: any) => {
+    const aStr = a.issuer ? `${a.code}:${a.issuer}` : a.code
+    const bStr = b.issuer ? `${b.code}:${b.issuer}` : b.code
+    return [aStr, bStr].sort().join('/')
+  },
+}))
+
+import { registerPairsRoutes } from '../routes/pairs'
+
+const ADMIN_KEY = 'test-admin-key-abc'
+const VALID_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5'
+
+async function buildApp() {
+  const savedKey = process.env.ADMIN_API_KEY
+  process.env.ADMIN_API_KEY = ADMIN_KEY
+  const app = Fastify({ logger: false })
+  await registerPairsRoutes(app)
+  await app.ready()
+  // restore after app init
+  if (savedKey === undefined) delete process.env.ADMIN_API_KEY
+  else process.env.ADMIN_API_KEY = savedKey
+  return app
+}
+
+beforeEach(() => {
+  process.env.ADMIN_API_KEY = ADMIN_KEY
+  mockHasPair.mockReset().mockReturnValue(false)
+  mockRegisterPair.mockReset().mockReturnValue(true)
+  mockPersistPair.mockReset().mockResolvedValue(undefined)
+  mockGetActivePairs.mockReset().mockReturnValue([])
+})
+
+describe('POST /pairs', () => {
+  it('adds a new pair and returns 201 with pairKey', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/pairs',
+      headers: { 'x-admin-key': ADMIN_KEY, 'content-type': 'application/json' },
+      payload: { assetA: 'XLM:native', assetB: `USDC:${VALID_ISSUER}` },
+    })
+
+    expect(res.statusCode).toBe(201)
+    const body = res.json()
+    expect(body).toHaveProperty('pairKey')
+    expect(mockRegisterPair).toHaveBeenCalledOnce()
+    expect(mockPersistPair).toHaveBeenCalledOnce()
+  })
+
+  it('returns 401 when no auth key provided', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/pairs',
+      headers: { 'content-type': 'application/json' },
+      payload: { assetA: 'XLM:native', assetB: `USDC:${VALID_ISSUER}` },
+    })
+
+    expect(res.statusCode).toBe(401)
+    expect(mockRegisterPair).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when wrong auth key provided', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/pairs',
+      headers: { 'x-admin-key': 'wrong-key', 'content-type': 'application/json' },
+      payload: { assetA: 'XLM:native', assetB: `USDC:${VALID_ISSUER}` },
+    })
+
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('returns 400 when assetA is missing', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/pairs',
+      headers: { 'x-admin-key': ADMIN_KEY, 'content-type': 'application/json' },
+      payload: { assetB: `USDC:${VALID_ISSUER}` },
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/assetA/)
+  })
+
+  it('returns 400 for invalid assetA issuer format', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/pairs',
+      headers: { 'x-admin-key': ADMIN_KEY, 'content-type': 'application/json' },
+      payload: { assetA: 'XLM:NOTAVALIDISSUER', assetB: `USDC:${VALID_ISSUER}` },
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/assetA/)
+  })
+
+  it('returns 409 when pair already exists', async () => {
+    mockHasPair.mockReturnValue(true)
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/pairs',
+      headers: { 'x-admin-key': ADMIN_KEY, 'content-type': 'application/json' },
+      payload: { assetA: 'XLM:native', assetB: `USDC:${VALID_ISSUER}` },
+    })
+
+    expect(res.statusCode).toBe(409)
+    expect(res.json().error).toMatch(/already/)
+    expect(mockRegisterPair).not.toHaveBeenCalled()
+  })
+
+  it('accepts Bearer token in Authorization header', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/pairs',
+      headers: { 'authorization': `Bearer ${ADMIN_KEY}`, 'content-type': 'application/json' },
+      payload: { assetA: 'XLM:native', assetB: `USDC:${VALID_ISSUER}` },
+    })
+
+    expect(res.statusCode).toBe(201)
+  })
+})
+
+describe('GET /pairs', () => {
+  it('returns the list of active pairs', async () => {
+    mockGetActivePairs.mockReturnValue([
+      { pairKey: 'USDC/XLM', assetA: { code: 'XLM', issuer: null }, assetB: { code: 'USDC', issuer: VALID_ISSUER } },
+    ])
+    const app = await buildApp()
+
+    const res = await app.inject({ method: 'GET', url: '/pairs' })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().pairs).toHaveLength(1)
+    expect(res.json().pairs[0].pairKey).toBe('USDC/XLM')
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,12 @@ import { registerRESTRoutes } from './api/rest'
 import { registerGraphQL } from './api/graphql'
 import { registerWebhookRoutes } from './routes/webhooks'
 import { registerCandleRoutes } from './routes/candles'
+import { registerPairsRoutes } from './routes/pairs'
 import { registerX402 } from './middleware/x402'
 import { startSDEXIngester } from './ingesters/sdex'
 import { startAMMIngester } from './ingesters/amm'
 import { createAggregateQueue, startAggregateWorker, scheduleAggregateRefresh } from './jobs/aggregateRefresh'
+import { loadPersistedPairs, getActivePairs } from './pairsRegistry'
 
 async function main() {
   // ── Ensure DB schema is up-to-date ────────────────────────────────────────
@@ -28,6 +30,9 @@ async function main() {
   await pgPool.connect()
   console.log('[lens] PostgreSQL connected')
 
+  // ── Load persisted runtime pairs ──────────────────────────────────────────
+  await loadPersistedPairs()
+
   // ── Fastify API server ────────────────────────────────────────────────────
   const app = Fastify({ logger: { level: 'warn' } })
   await app.register(cors, { origin: true })
@@ -37,6 +42,7 @@ async function main() {
   await registerRESTRoutes(app)
   await registerWebhookRoutes(app)
   await registerCandleRoutes(app)
+  await registerPairsRoutes(app)
   await registerGraphQL(app)
 
   await app.listen({ port: config.api.port, host: config.api.host })
@@ -64,7 +70,7 @@ async function main() {
   restartIngester('SDEX', startSDEXIngester)
   restartIngester('AMM', startAMMIngester)
 
-  console.log(`[lens] Watching ${config.pairs.length} pairs: ${config.pairs.map(p => p.pairKey).join(', ')}`)
+  console.log(`[lens] Watching ${getActivePairs().length} pairs: ${getActivePairs().map(p => p.pairKey).join(', ')}`)
 }
 
 main().catch(err => {

--- a/src/ingesters/amm.ts
+++ b/src/ingesters/amm.ts
@@ -1,5 +1,6 @@
 import { Horizon } from '@stellar/stellar-sdk'
 import { config } from '../config'
+import { getActivePairs } from '../pairsRegistry'
 import { upsertPricePoints, getIndexerCursor, setIndexerCursor, prisma } from '../db'
 import { dispatchPriceUpdate } from '../webhookDispatcher'
 import type { WatchedPair } from '../types'
@@ -154,10 +155,10 @@ async function sleep(ms: number) {
 }
 
 export async function startAMMIngester(): Promise<void> {
-  console.log(`[amm] Starting AMM ingester for ${config.pairs.length} pairs`)
+  console.log(`[amm] Starting AMM ingester for ${getActivePairs().length} pairs`)
 
   while (true) {
-    for (const pair of config.pairs) {
+    for (const pair of getActivePairs()) {
       const pools = await fetchPools(pair)
       console.log(`[amm] ${pair.pairKey}: found ${pools.length} AMM pools`)
 

--- a/src/ingesters/sdex.ts
+++ b/src/ingesters/sdex.ts
@@ -1,5 +1,6 @@
 import { Horizon, Asset } from '@stellar/stellar-sdk'
 import { config } from '../config'
+import { getActivePairs } from '../pairsRegistry'
 import { upsertPricePoints, getIndexerCursor, setIndexerCursor } from '../db'
 import { dispatchPriceUpdate } from '../webhookDispatcher'
 import type { WatchedPair } from '../types'
@@ -82,10 +83,10 @@ async function sleep(ms: number) {
 }
 
 export async function startSDEXIngester(): Promise<void> {
-  console.log(`[sdex] Starting SDEX ingester for ${config.pairs.length} pairs`)
+  console.log(`[sdex] Starting SDEX ingester for ${getActivePairs().length} pairs`)
 
   while (true) {
-    await Promise.all(config.pairs.map(pair => ingestPair(pair)))
+    await Promise.all(getActivePairs().map(pair => ingestPair(pair)))
     await sleep(config.indexer.pollIntervalMs)
   }
 }

--- a/src/pairsRegistry.ts
+++ b/src/pairsRegistry.ts
@@ -1,0 +1,67 @@
+import { config } from './config'
+import { prisma } from './db'
+import type { WatchedPair, AssetId } from './types'
+
+// ─── Mutable runtime pairs store ─────────────────────────────────────────────
+const activePairs: WatchedPair[] = [...config.pairs]
+
+export function getActivePairs(): readonly WatchedPair[] {
+  return activePairs
+}
+
+export function hasPair(pairKey: string): boolean {
+  return activePairs.some(p => p.pairKey === pairKey)
+}
+
+/** Add a new pair to the in-memory registry. Returns false if already present. */
+export function registerPair(pair: WatchedPair): boolean {
+  if (hasPair(pair.pairKey)) return false
+  activePairs.push(pair)
+  return true
+}
+
+// ─── Asset format helpers ─────────────────────────────────────────────────────
+export function parseAssetStr(str: string): AssetId | null {
+  const parts = str.split(':')
+  if (parts.length < 1 || parts.length > 2) return null
+  const code = parts[0].trim().toUpperCase()
+  if (!code || code.length > 12) return null
+  const issuer = parts[1] && parts[1].toLowerCase() !== 'native' ? parts[1].trim() : null
+  if (issuer && !/^G[A-Z2-7]{55}$/.test(issuer)) return null
+  return { code, issuer }
+}
+
+export function makePairKey(a: AssetId, b: AssetId): string {
+  const aStr = a.issuer ? `${a.code}:${a.issuer}` : a.code
+  const bStr = b.issuer ? `${b.code}:${b.issuer}` : b.code
+  return [aStr, bStr].sort().join('/')
+}
+
+// ─── Persistence ──────────────────────────────────────────────────────────────
+/** Persist a new pair to DB so it survives restarts. */
+export async function persistPair(pair: WatchedPair): Promise<void> {
+  await prisma.pairConfig.upsert({
+    where: { pairKey: pair.pairKey },
+    create: {
+      pairKey: pair.pairKey,
+      assetACode: pair.assetA.code,
+      assetAIssuer: pair.assetA.issuer,
+      assetBCode: pair.assetB.code,
+      assetBIssuer: pair.assetB.issuer,
+    },
+    update: {},
+  })
+}
+
+/** Load persisted pairs from DB and merge into the active registry. */
+export async function loadPersistedPairs(): Promise<void> {
+  const rows = await prisma.pairConfig.findMany()
+  for (const row of rows) {
+    const pair: WatchedPair = {
+      assetA: { code: row.assetACode, issuer: row.assetAIssuer },
+      assetB: { code: row.assetBCode, issuer: row.assetBIssuer },
+      pairKey: row.pairKey,
+    }
+    registerPair(pair)
+  }
+}

--- a/src/routes/pairs.ts
+++ b/src/routes/pairs.ts
@@ -1,0 +1,58 @@
+import type { FastifyInstance } from 'fastify'
+import { getActivePairs, parseAssetStr, makePairKey, registerPair, persistPair, hasPair } from '../pairsRegistry'
+
+export async function registerPairsRoutes(app: FastifyInstance) {
+  // GET /pairs — list all active pairs (already exists in rest.ts but this is the authoritative source)
+  app.get('/pairs', async () => ({
+    pairs: getActivePairs().map(p => ({
+      pairKey: p.pairKey,
+      assetA: p.assetA,
+      assetB: p.assetB,
+    })),
+  }))
+
+  // POST /pairs — add a new trading pair at runtime
+  app.post<{
+    Body: { assetA?: string; assetB?: string }
+  }>('/pairs', async (req, reply) => {
+    // Auth check — read at request time so env can be set after module load
+    const ADMIN_API_KEY = process.env.ADMIN_API_KEY
+    const key = req.headers['x-admin-key'] ?? req.headers['authorization']?.replace(/^Bearer /, '')
+    if (!ADMIN_API_KEY || key !== ADMIN_API_KEY) {
+      return reply.status(401).send({ error: 'Unauthorized — provide a valid X-Admin-Key header' })
+    }
+
+    const { assetA: assetAStr, assetB: assetBStr } = req.body ?? {}
+
+    if (!assetAStr || !assetBStr) {
+      return reply.status(400).send({ error: 'assetA and assetB are required' })
+    }
+
+    const assetA = parseAssetStr(assetAStr)
+    if (!assetA) {
+      return reply.status(400).send({
+        error: `Invalid assetA format "${assetAStr}". Expected CODE or CODE:ISSUER (e.g. XLM:native or USDC:GBBD47...)`,
+      })
+    }
+
+    const assetB = parseAssetStr(assetBStr)
+    if (!assetB) {
+      return reply.status(400).send({
+        error: `Invalid assetB format "${assetBStr}". Expected CODE or CODE:ISSUER (e.g. XLM:native or USDC:GBBD47...)`,
+      })
+    }
+
+    const pairKey = makePairKey(assetA, assetB)
+
+    if (hasPair(pairKey)) {
+      return reply.status(409).send({ error: `Pair ${pairKey} is already being watched` })
+    }
+
+    const pair = { assetA, assetB, pairKey }
+    registerPair(pair)
+    await persistPair(pair)
+
+    console.log(`[pairs] Added runtime pair: ${pairKey}`)
+    return reply.status(201).send({ pairKey, assetA, assetB })
+  })
+}


### PR DESCRIPTION
Closes #30

Conflict-resolved rebase of Salmatcre8/feat/runtime-pair-management onto main (after #37 candles was merged).

Adds `POST /pairs` so operators can add new trading pairs without restarting the service. New pairs are ingested within one poll cycle and persist across restarts via a DB-backed registry.

- `src/pairsRegistry.ts` — mutable pairs store, initialised from config, accepts runtime additions
- `POST /pairs` — auth via X-Admin-Key, validates asset format, 409 on duplicate, 201 on success
- `GET /pairs` — lists active pairs
- `src/routes/pairs.ts` — route handlers
- Prisma `PairConfig` model — persists runtime pairs across restarts
- SDEX and AMM ingesters now call `getActivePairs()` instead of frozen `config.pairs`
- 8 vitest tests covering auth, validation, conflict, Bearer token, and list