### PR TITLE
feat(api): add /pairs endpoint listing all watched trading pairs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,27 +1,54 @@
-# Stellar
-HORIZON_URL=https://horizon-testnet.stellar.org
-RPC_URL=https://soroban-testnet.stellar.org
-NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+# --- General ---
+# Environment: development, test, production
+NODE_ENV=development
 
-# Watched pairs: comma-separated "ASSET_A_CODE:ASSET_A_ISSUER/ASSET_B_CODE:ASSET_B_ISSUER"
-# Use "native" for XLM issuer
-# Example: XLM/USDC pair on testnet
-WATCHED_PAIRS=XLM:native/USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
-
-# PostgreSQL
-DATABASE_URL=postgresql://lens:lens@localhost:5432/lens
-
-# Redis
-REDIS_URL=redis://localhost:6379
-
-# API
+# --- Server ---
+# Port to listen on (default: 3002)
 PORT=3002
+# Host to bind to (default: 0.0.0.0)
 HOST=0.0.0.0
 
-# Indexer
+# --- Database ---
+# PostgreSQL connection string with credentials
+DATABASE_URL=postgresql://lens:lens@localhost:5432/lens
+
+# --- Cache & Performance ---
+# Redis connection URL for caching and queues
+REDIS_URL=redis://localhost:6379
+# How long to cache price responses in seconds (default: 10)
+PRICE_CACHE_TTL=10
+
+# --- Stellar Network ---
+# URL of the Horizon server (default: testnet)
+HORIZON_URL=https://horizon-testnet.stellar.org
+# URL of the Soroban RPC server (default: testnet)
+RPC_URL=https://soroban-testnet.stellar.org
+# Stellar network passphrase
+NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+# Network mode: mainnet or testnet (used for x402 gating logic)
+STELLAR_NETWORK=testnet
+
+# --- Indexer Configuration ---
+# Frequency of polling for new trades/snapshots in milliseconds (default: 5000)
 POLL_INTERVAL_MS=5000
+# Number of SDEX trades to fetch per page (default: 200)
 SDEX_PAGE_SIZE=200
+# Number of AMM trades to fetch per page (default: 200)
 AMM_PAGE_SIZE=200
 
-# Cache TTL in seconds
-PRICE_CACHE_TTL=10
+# --- Auth & Security ---
+# Secret key required for admin endpoints (e.g., adding/removing pairs)
+ADMIN_API_KEY=super-secret-admin-key
+
+# --- App Logic ---
+# Comma-separated list of asset pairs to watch. 
+# Format: "CODE:ISSUER/CODE:ISSUER". Use "native" for XLM.
+# Example: XLM/USDC on testnet
+WATCHED_PAIRS=XLM:native/USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+
+# --- x402 Payment Gate ---
+# Stellar public key where API payments should be sent. 
+# If unset, x402 gating is disabled.
+ORACLE_PAYMENT_ADDRESS=GD...
+# URL of the x402 facilitator (default: https://facilitator.stellar.org)
+X402_FACILITATOR_URL=https://facilitator.stellar.org

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ query {
 }
 ```
 
+## Documentation
+Detailed system design and data flow diagrams can be found in the [Architecture Overview](docs/architecture.md).
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ npm run db:push
 npm run dev
 ```
 
+## Environment Variables
+
+| Variable | Description | Default | Required |
+|---|---|---|---|
+| `NODE_ENV` | Environment mode (`development`, `test`, `production`) | `development` | No |
+| `PORT` | API server port | `3002` | No |
+| `HOST` | API server host | `0.0.0.0` | No |
+| `DATABASE_URL` | PostgreSQL connection string | - | **Yes** |
+| `REDIS_URL` | Redis connection string | - | **Yes** |
+| `PRICE_CACHE_TTL` | Cache duration for price data (seconds) | `10` | No |
+| `HORIZON_URL` | Stellar Horizon server URL | - | No |
+| `RPC_URL` | Soroban RPC server URL | - | No |
+| `NETWORK_PASSPHRASE` | Stellar network passphrase | - | No |
+| `STELLAR_NETWORK` | `mainnet` or `testnet` (for x402 logic) | `testnet` | No |
+| `POLL_INTERVAL_MS` | Indexer polling frequency (ms) | `5000` | No |
+| `SDEX_PAGE_SIZE` | Trades per page for SDEX ingestion | `200` | No |
+| `AMM_PAGE_SIZE` | Trades per page for AMM ingestion | `200` | No |
+| `ADMIN_API_KEY` | Key for admin route authentication | - | No |
+| `WATCHED_PAIRS` | Comma-separated list of asset pairs to index | - | **Yes** |
+| `ORACLE_PAYMENT_ADDRESS` | Stellar address for x402 API payments | - | No* |
+| `X402_FACILITATOR_URL` | x402 facilitator service URL | - | No |
+
+*\*Required if enabling x402 payment gating.*
+
 ## Stack
 - **Runtime:** Node.js 20 + TypeScript
 - **API:** Fastify + Mercurius (GraphQL)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,74 @@
+# Architecture Overview
+
+Lens is a unified price aggregation engine for the Stellar network. It bridges the gap between Stellar's Classic Order Book (SDEX) and Liquidity Pools (AMM) by providing a single source of truth for asset pricing, VWAP calculations, and optimal trade routing.
+
+## Data Flow
+
+The following diagram illustrates how data flows from the Stellar network through our ingesters, into the database, and finally out through our API layers.
+
+```mermaid
+graph TD
+    subgraph Stellar Network
+        SDEX[SDEX Trades]
+        AMM[AMM Pools]
+    end
+
+    subgraph Ingestion Layer
+        SI[SDEX Ingester]
+        AI[AMM Ingester]
+    end
+
+    subgraph Storage Layer
+        DB[(PostgreSQL / TimescaleDB)]
+        PP[price_points table]
+        PS[pool_snapshots table]
+    end
+
+    subgraph Aggregation Layer
+        BR[bestRoute Logic]
+    end
+
+    subgraph API Layer
+        REST[REST API /price]
+        GQL[GraphQL API]
+        X402{x402 Payment Gate}
+    end
+
+    SDEX -->|Horizon Stream| SI
+    AMM -->|Polling| AI
+
+    SI --> PP
+    AI --> PS
+    AI --> PP
+
+    PP --> BR
+    PS --> BR
+
+    BR --> X402
+    X402 --> REST
+    X402 --> GQL
+```
+
+## System Components
+
+### 1. Ingestion Layer
+Lens utilizes two distinct ingestion strategies to maintain up-to-date pricing data:
+
+*   **SDEX Ingester**: Streams trades directly from Stellar Horizon for watched asset pairs. It processes individual trade events in real-time, extracting price and volume data which is then persisted to the `price_points` table.
+*   **AMM Ingester**: Polls Horizon for liquidity pool snapshots and recent AMM trades. It stores pool reserves (Asset A/B amounts) in `pool_snapshots` and individual trades in `price_points`. This allows Lens to calculate spot prices based on reserve ratios even when no trades have occurred recently.
+
+### 2. Storage Layer
+Data is stored in a PostgreSQL database optimized with TimescaleDB for time-series efficiency.
+*   **`price_points`**: A unified table for all trade events across both SDEX and AMM. This enables high-performance VWAP (Volume Weighted Average Price) calculations over various time windows (1m, 5m, 1h, 24h).
+*   **`pool_snapshots`**: Stores the reserve state of AMM liquidity pools, which is critical for slippage estimation and constant-product price calculations.
+
+### 3. Aggregation & Routing (`bestRoute`)
+When a price is requested, the `bestRoute` engine compares the available liquidity on both SDEX and AMM:
+*   **SDEX Pricing**: Fetches real-time path payment quotes from Horizon to determine the effective rate for a specific trade size.
+*   **AMM Pricing**: Uses the constant-product formula (`x * y = k`) against the latest pool snapshots to estimate the output and slippage.
+*   **Optimal Routing**: Compares the rates and recommends the best execution path (SDEX, AMM, or a SPLIT for large orders) to minimize slippage for the user.
+
+### 4. API Layer & x402 Payment Gate
+The system exposes both REST and GraphQL interfaces. To monetize the high-fidelity data, Lens implements the **x402 protocol**.
+
+The **x402 Payment Gate** is a middleware that intercepts requests to premium endpoints (like `/price`, `/pools`, and `/candles`). If a valid `x-payment` header containing a signed Stellar transaction is not present, the server returns a `402 Payment Required` status along with the payment requirements (price, destination address, and network). This ensures that every high-value API call is backed by a micropayment, enabling a "pay-per-query" business model.

--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -33,14 +33,6 @@ export async function registerRESTRoutes(app: FastifyInstance) {
     }
   })
 
-  // GET /pairs
-  app.get('/pairs', async () => ({
-    pairs: config.pairs.map(p => ({
-      pairKey: p.pairKey,
-      assetA: p.assetA,
-      assetB: p.assetB,
-    })),
-  }))
 
   // GET /price/:assetA/:assetB
   app.get<{ Params: { assetA: string; assetB: string } }>(

--- a/src/routes/pairs.ts
+++ b/src/routes/pairs.ts
@@ -1,15 +1,40 @@
 import type { FastifyInstance } from 'fastify'
 import { getActivePairs, parseAssetStr, makePairKey, registerPair, persistPair, hasPair } from '../pairsRegistry'
+import { pgPool } from '../db'
 
 export async function registerPairsRoutes(app: FastifyInstance) {
-  // GET /pairs — list all active pairs (already exists in rest.ts but this is the authoritative source)
-  app.get('/pairs', async () => ({
-    pairs: getActivePairs().map(p => ({
-      pairKey: p.pairKey,
-      assetA: p.assetA,
-      assetB: p.assetB,
-    })),
-  }))
+  // GET /pairs — list all active pairs with latest price metadata
+  app.get('/pairs', async () => {
+    const activePairs = getActivePairs()
+    
+    // Fetch latest price for all pairs in one go
+    const result = await pgPool.query(`
+      SELECT DISTINCT ON (pair_key) pair_key, price, timestamp
+      FROM price_points
+      ORDER BY pair_key, timestamp DESC
+    `)
+    
+    const latestPrices = new Map<string, { price: number; timestamp: Date }>()
+    result.rows.forEach(row => {
+      latestPrices.set(row.pair_key, {
+        price: parseFloat(row.price),
+        timestamp: row.timestamp,
+      })
+    })
+
+    return {
+      pairs: activePairs.map(p => {
+        const latest = latestPrices.get(p.pairKey)
+        return {
+          pairKey: p.pairKey,
+          assetA: p.assetA,
+          assetB: p.assetB,
+          latestPrice: latest?.price ?? null,
+          lastUpdated: latest?.timestamp ?? null,
+        }
+      })
+    }
+  })
 
   // POST /pairs — add a new trading pair at runtime
   app.post<{


### PR DESCRIPTION

## Summary
This PR adds the `GET /pairs` endpoint to allow clients to discover all watched trading pairs and their latest pricing metadata.

## Related issue
Closes #29

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] CI / tooling


## Changes
- **Enhanced GET /pairs**: Added `latestPrice` and `lastUpdated` fields to the response.
- **Consolidated Routes**: Moved the authoritative `/pairs` logic to `src/routes/pairs.ts` and removed the redundant placeholder in `src/api/rest.ts`.

