### PR TITLE
feat(ingester): add Soroswap AMM pool price ingester via Soroban RPC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,14 +41,21 @@ AMM_PAGE_SIZE=200
 ADMIN_API_KEY=super-secret-admin-key
 
 # --- App Logic ---
-# Comma-separated list of asset pairs to watch. 
+# Comma-separated list of asset pairs to watch.
 # Format: "CODE:ISSUER/CODE:ISSUER". Use "native" for XLM.
 # Example: XLM/USDC on testnet
 WATCHED_PAIRS=XLM:native/USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
 
 # --- x402 Payment Gate ---
-# Stellar public key where API payments should be sent. 
+# Stellar public key where API payments should be sent.
 # If unset, x402 gating is disabled.
 ORACLE_PAYMENT_ADDRESS=GD...
 # URL of the x402 facilitator (default: https://facilitator.stellar.org)
 X402_FACILITATOR_URL=https://facilitator.stellar.org
+
+# --- Soroswap AMM Ingester ---
+# Mainnet Soroswap factory contract address
+# See: https://github.com/soroswap/core
+SOROSWAP_FACTORY_ADDRESS=CA4HEQTL2WPEUYKYKCDOHCDNIV4QHNJ7EL4J4NQ6VADP7SYHVRYZ7AW2
+# How often to poll Soroswap pool reserves in milliseconds (default: 60000 = 60s)
+SOROSWAP_POLL_INTERVAL_MS=60000

--- a/src/__tests__/soroswapIngester.test.ts
+++ b/src/__tests__/soroswapIngester.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for the Soroswap AMM ingester.
+ *
+ * Tests cover:
+ * - calcSpotPrice: pure function — no mocks needed
+ * - ingestPool: mocked upsertPricePoints + dispatchPriceUpdate
+ * - fetchSoroswapTokenList: mocked global fetch
+ * - ingestPair: pair filtering / skipping logic
+ */
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+vi.mock('../db', () => ({
+  upsertPricePoints: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../webhookDispatcher', () => ({
+  dispatchPriceUpdate: vi.fn().mockResolvedValue(undefined),
+}))
+
+// We mock fetchPoolReserves and fetchPoolsFromFactory at module level so
+// ingestPool / ingestPair tests can control RPC responses without a live node.
+vi.mock('../ingesters/soroswap', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../ingesters/soroswap')>()
+  return {
+    ...actual,
+    fetchPoolReserves: vi.fn(),
+    fetchPoolsFromFactory: vi.fn(),
+    fetchSoroswapTokenList: vi.fn(),
+  }
+})
+
+// ── Imports ──────────────────────────────────────────────────────────────────
+import {
+  calcSpotPrice,
+  ingestPool,
+  ingestPair,
+  fetchSoroswapTokenList,
+  fetchPoolReserves,
+  fetchPoolsFromFactory,
+  type PoolEntry,
+  type SoroswapToken,
+} from '../ingesters/soroswap'
+import { upsertPricePoints } from '../db'
+import { dispatchPriceUpdate } from '../webhookDispatcher'
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+const mockPair = {
+  pairKey: 'USDC/XLM',
+  assetA: { code: 'XLM', issuer: null },
+  assetB: {
+    code: 'USDC',
+    issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+  },
+}
+
+const xlmToken: SoroswapToken = {
+  address: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM',
+  symbol: 'XLM',
+  name: 'Stellar Lumens',
+  decimals: 7,
+}
+
+const usdcToken: SoroswapToken = {
+  address: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75',
+  symbol: 'USDC',
+  name: 'USD Coin',
+  decimals: 7,
+}
+
+// ── calcSpotPrice ─────────────────────────────────────────────────────────────
+describe('calcSpotPrice', () => {
+  it('returns reserveA / reserveB as a number', () => {
+    expect(calcSpotPrice(1000n, 200n)).toBeCloseTo(5.0)
+  })
+
+  it('returns 0 when reserveA is zero (empty pool guard)', () => {
+    expect(calcSpotPrice(0n, 200n)).toBe(0)
+  })
+
+  it('returns 0 when reserveB is zero (empty pool guard)', () => {
+    expect(calcSpotPrice(1000n, 0n)).toBe(0)
+  })
+
+  it('handles large i128 reserves correctly', () => {
+    // 10_000_000 / 2_000_000 = 5.0 (7-decimal precision amounts)
+    expect(calcSpotPrice(10_000_000n, 2_000_000n)).toBeCloseTo(5.0)
+  })
+
+  it('handles 1:1 ratio', () => {
+    expect(calcSpotPrice(5000n, 5000n)).toBe(1)
+  })
+})
+
+// ── ingestPool ────────────────────────────────────────────────────────────────
+describe('ingestPool', () => {
+  const mockPoolEntry: PoolEntry = {
+    poolAddress: 'CPOOL000000000000000000000000000000000000000000000000001234',
+    tokenA: xlmToken,
+    tokenB: usdcToken,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('stores a price point when reserves are non-zero', async () => {
+    ;(fetchPoolReserves as ReturnType<typeof vi.fn>).mockResolvedValue([10_000_000n, 2_000_000n])
+
+    await ingestPool(mockPoolEntry, mockPair as any)
+
+    expect(upsertPricePoints).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'soroswap_amm',
+          price: expect.closeTo(5.0, 5),
+          poolId: mockPoolEntry.poolAddress,
+        }),
+      ])
+    )
+    expect(dispatchPriceUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ assetA: 'XLM', assetB: 'USDC' })
+    )
+  })
+
+  it('skips price storage when pool is empty (zero reserves)', async () => {
+    ;(fetchPoolReserves as ReturnType<typeof vi.fn>).mockResolvedValue([0n, 0n])
+
+    await ingestPool(mockPoolEntry, mockPair as any)
+
+    expect(upsertPricePoints).not.toHaveBeenCalled()
+    expect(dispatchPriceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('skips price storage when fetchPoolReserves returns null (RPC error)', async () => {
+    ;(fetchPoolReserves as ReturnType<typeof vi.fn>).mockResolvedValue(null)
+
+    await ingestPool(mockPoolEntry, mockPair as any)
+
+    expect(upsertPricePoints).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when upsertPricePoints rejects', async () => {
+    ;(fetchPoolReserves as ReturnType<typeof vi.fn>).mockResolvedValue([1000n, 200n])
+    ;(upsertPricePoints as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB error'))
+
+    // Should not propagate the error
+    await expect(ingestPool(mockPoolEntry, mockPair as any)).resolves.toBeUndefined()
+  })
+})
+
+// ── ingestPair ────────────────────────────────────────────────────────────────
+describe('ingestPair', () => {
+  const tokens = [xlmToken, usdcToken]
+  const factory = 'CA4HEQTL2WPEUYKYKCDOHCDNIV4QHNJ7EL4J4NQ6VADP7SYHVRYZ7AW2'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls fetchPoolsFromFactory with correct token addresses', async () => {
+    ;(fetchPoolsFromFactory as ReturnType<typeof vi.fn>).mockResolvedValue([])
+
+    await ingestPair(mockPair as any, tokens, factory)
+
+    expect(fetchPoolsFromFactory).toHaveBeenCalledWith(
+      factory,
+      xlmToken.address,
+      usdcToken.address
+    )
+  })
+
+  it('skips silently when one token is not in the token list', async () => {
+    const pairWithUnknownToken = {
+      ...mockPair,
+      assetB: { code: 'UNKNOWN', issuer: null },
+      pairKey: 'UNKNOWN/XLM',
+    }
+
+    await ingestPair(pairWithUnknownToken as any, tokens, factory)
+
+    expect(fetchPoolsFromFactory).not.toHaveBeenCalled()
+  })
+
+  it('skips silently when factory returns no pools', async () => {
+    ;(fetchPoolsFromFactory as ReturnType<typeof vi.fn>).mockResolvedValue([])
+
+    await ingestPair(mockPair as any, tokens, factory)
+
+    expect(upsertPricePoints).not.toHaveBeenCalled()
+  })
+})
+
+// ── fetchSoroswapTokenList ────────────────────────────────────────────────────
+describe('fetchSoroswapTokenList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns tokens from a successful fetch', async () => {
+    ;(fetchSoroswapTokenList as ReturnType<typeof vi.fn>).mockResolvedValue([xlmToken, usdcToken])
+
+    const result = await fetchSoroswapTokenList()
+    expect(result).toHaveLength(2)
+    expect(result[0].symbol).toBe('XLM')
+  })
+
+  it('returns empty array on fetch failure', async () => {
+    ;(fetchSoroswapTokenList as ReturnType<typeof vi.fn>).mockResolvedValue([])
+
+    const result = await fetchSoroswapTokenList()
+    expect(result).toEqual([])
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,5 +56,17 @@ export const config = {
   cache: {
     priceTtl: parseInt(process.env.PRICE_CACHE_TTL ?? '10', 10),
   },
+  // ── Soroswap AMM Ingester ──────────────────────────────────────────────────
+  soroswap: {
+    /** Mainnet Soroswap factory contract address */
+    factoryAddress:
+      process.env.SOROSWAP_FACTORY_ADDRESS ??
+      'CA4HEQTL2WPEUYKYKCDOHCDNIV4QHNJ7EL4J4NQ6VADP7SYHVRYZ7AW2',
+    /** Poll interval in ms (default 60s, aligned with classic AMM ingester) */
+    pollIntervalMs: parseInt(
+      process.env.SOROSWAP_POLL_INTERVAL_MS ?? '60000',
+      10
+    ),
+  },
   pairs: parseWatchedPairs(),
 } as const

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { registerWebSocket } from './api/websocket'
 
 import { startSDEXIngester } from './ingesters/sdex'
 import { startAMMIngester } from './ingesters/amm'
+import { startSoroswapIngester } from './ingesters/soroswap'
 import { createAggregateQueue, startAggregateWorker, scheduleAggregateRefresh } from './jobs/aggregateRefresh'
 import { loadPersistedPairs, getActivePairs } from './pairsRegistry'
 
@@ -43,7 +44,7 @@ async function main() {
   await app.register(rateLimit, {
     max: 100,
     timeWindow: '1 minute',
-    allowList: (req) => req.url === '/status', // Allow /status to have its own limit or be bypassed
+    allowList: (req) => req.url === '/status',
     errorResponseBuilder: (req, context) => ({
       statusCode: 429,
       error: 'Too Many Requests',
@@ -73,7 +74,6 @@ async function main() {
   await registerGraphQL(app)
   await registerWebSocket(app)
 
-
   await app.listen({ port: config.api.port, host: config.api.host })
   console.log(`[lens] API listening on http://${config.api.host}:${config.api.port}`)
   console.log(`[lens] GraphiQL at http://localhost:${config.api.port}/graphiql`)
@@ -89,6 +89,8 @@ async function main() {
   }
 
   // ── Ingesters (run in background — infinite loops) ────────────────────────
+  // Each ingester is independently fault-isolated via restartIngester.
+  // A crash in the Soroswap ingester cannot take down SDEX or AMM.
   console.log('[lens] Starting ingesters...')
   const restartIngester = (name: string, fn: () => Promise<void>) => {
     fn().catch(err => {
@@ -98,6 +100,7 @@ async function main() {
   }
   restartIngester('SDEX', startSDEXIngester)
   restartIngester('AMM', startAMMIngester)
+  restartIngester('Soroswap', startSoroswapIngester)
 
   console.log(`[lens] Watching ${getActivePairs().length} pairs: ${getActivePairs().map(p => p.pairKey).join(', ')}`)
 }

--- a/src/ingesters/soroswap.ts
+++ b/src/ingesters/soroswap.ts
@@ -1,0 +1,356 @@
+/**
+ * Soroswap AMM Pool Price Ingester
+ *
+ * Polls Soroswap Soroban pool reserves via Soroban RPC simulation,
+ * calculates constant-product spot prices, and stores them in price_points
+ * with source = 'soroswap_amm'. Runs independently of the SDEX and Horizon
+ * AMM ingesters — a crash here cannot affect them.
+ *
+ * Issue: #48
+ */
+
+import {
+  Contract,
+  rpc as SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  Keypair,
+  scValToNative,
+  Account,
+} from '@stellar/stellar-sdk'
+import { config } from '../config'
+import { getActivePairs } from '../pairsRegistry'
+import { upsertPricePoints } from '../db'
+import { dispatchPriceUpdate } from '../webhookDispatcher'
+import type { WatchedPair } from '../types'
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const SOROSWAP_TOKEN_LIST_URL =
+  'https://raw.githubusercontent.com/soroswap/token-list/main/tokenList.json'
+
+// Ephemeral fee-payer account (no real funds needed for simulation)
+const FEE_PAYER_KEYPAIR = Keypair.random()
+
+// In-memory last-price tracker for webhook delta dispatch
+const lastPrice = new Map<string, number>()
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface SoroswapToken {
+  address: string
+  symbol: string
+  name: string
+  decimals: number
+}
+
+export interface SoroswapTokenList {
+  tokens: SoroswapToken[]
+}
+
+export interface PoolEntry {
+  poolAddress: string
+  tokenA: SoroswapToken
+  tokenB: SoroswapToken
+}
+
+// ── RPC client (lazy-initialised so tests can skip it) ────────────────────────
+
+let _rpc: SorobanRpc.Server | null = null
+function getRpc(): SorobanRpc.Server {
+  if (!_rpc) {
+    _rpc = new SorobanRpc.Server(config.rpc.url, { allowHttp: true })
+  }
+  return _rpc
+}
+
+// ── Token-list helpers ────────────────────────────────────────────────────────
+
+/**
+ * Fetch Soroswap token list. Returns an empty array on failure so the ingester
+ * degrades gracefully without affecting other ingesters.
+ */
+export async function fetchSoroswapTokenList(): Promise<SoroswapToken[]> {
+  try {
+    const res = await fetch(SOROSWAP_TOKEN_LIST_URL)
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const data = (await res.json()) as SoroswapTokenList
+    return Array.isArray(data.tokens) ? data.tokens : []
+  } catch (err) {
+    console.error('[soroswap] Failed to fetch token list:', (err as Error).message)
+    return []
+  }
+}
+
+// ── Pool discovery ────────────────────────────────────────────────────────────
+
+/**
+ * Query the Soroswap factory contract's get_pools() to enumerate pool addresses
+ * for a specific token pair. Returns an empty array on RPC failure.
+ */
+export async function fetchPoolsFromFactory(
+  factoryAddress: string,
+  tokenA: string,
+  tokenB: string
+): Promise<string[]> {
+  try {
+    const rpc = getRpc()
+    const factory = new Contract(factoryAddress)
+    const account = new Account(FEE_PAYER_KEYPAIR.publicKey(), '0')
+    const networkPassphrase =
+      config.network.passphrase ?? Networks.PUBLIC
+
+    // Call factory.get_pools(tokenA, tokenB) — returns Vec<Address>
+    const { xdr: tokenAXdr } = (await rpc.getContractData(
+      factoryAddress,
+      factory.address().toScVal()
+    ).catch(() => ({ xdr: null }))) as { xdr: string | null }
+    void tokenAXdr // informational only; we use simulation below
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase,
+    })
+      .addOperation(
+        factory.call(
+          'get_pools',
+          new Contract(tokenA).address().toScVal(),
+          new Contract(tokenB).address().toScVal()
+        )
+      )
+      .setTimeout(30)
+      .build()
+
+    const sim = await rpc.simulateTransaction(tx)
+
+    if (SorobanRpc.Api.isSimulationError(sim)) {
+      console.debug(
+        `[soroswap] get_pools simulation error for ${tokenA}/${tokenB}:`,
+        sim.error
+      )
+      return []
+    }
+
+    if (!sim.result?.retval) return []
+
+    const pools = scValToNative(sim.result.retval) as string[]
+    return Array.isArray(pools) ? pools : []
+  } catch (err) {
+    console.debug(
+      '[soroswap] fetchPoolsFromFactory error:',
+      (err as Error).message
+    )
+    return []
+  }
+}
+
+// ── Reserve reading ───────────────────────────────────────────────────────────
+
+/**
+ * Read a Soroswap pool's reserves via Soroban RPC simulation.
+ * Returns [reserveA, reserveB] where A is `tokenAAddress`.
+ * Returns null on any RPC error.
+ */
+export async function fetchPoolReserves(
+  poolAddress: string
+): Promise<[bigint, bigint] | null> {
+  try {
+    const rpc = getRpc()
+    const pool = new Contract(poolAddress)
+    const account = new Account(FEE_PAYER_KEYPAIR.publicKey(), '0')
+    const networkPassphrase =
+      config.network.passphrase ?? Networks.PUBLIC
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase,
+    })
+      .addOperation(pool.call('get_reserves'))
+      .setTimeout(30)
+      .build()
+
+    const sim = await rpc.simulateTransaction(tx)
+
+    if (SorobanRpc.Api.isSimulationError(sim)) {
+      console.debug(
+        `[soroswap] get_reserves simulation error for pool ${poolAddress}:`,
+        sim.error
+      )
+      return null
+    }
+
+    if (!sim.result?.retval) return null
+
+    const reserves = scValToNative(sim.result.retval) as [bigint | number, bigint | number]
+    if (!Array.isArray(reserves) || reserves.length < 2) return null
+
+    return [BigInt(reserves[0]), BigInt(reserves[1])]
+  } catch (err) {
+    console.debug(
+      `[soroswap] fetchPoolReserves error for ${poolAddress}:`,
+      (err as Error).message
+    )
+    return null
+  }
+}
+
+// ── Spot price ────────────────────────────────────────────────────────────────
+
+/**
+ * Pure function: calculate spot price from constant-product reserves.
+ * Returns 0 if either reserve is zero (empty pool guard).
+ *
+ * price = reserveA / reserveB
+ * (price of assetB denominated in assetA)
+ */
+export function calcSpotPrice(reserveA: bigint, reserveB: bigint): number {
+  if (reserveA === 0n || reserveB === 0n) return 0
+  // Use Number division; reserves are i128 scaled to 7 decimal places
+  return Number(reserveA) / Number(reserveB)
+}
+
+// ── Per-pool ingestion ────────────────────────────────────────────────────────
+
+/**
+ * Fetch reserves for a single pool, compute spot price, and store a price point.
+ * Skips silently on empty pool or RPC failure — does not throw.
+ */
+export async function ingestPool(
+  poolEntry: PoolEntry,
+  pair: WatchedPair
+): Promise<void> {
+  try {
+    const reserves = await fetchPoolReserves(poolEntry.poolAddress)
+    if (!reserves) return
+
+    const [reserveA, reserveB] = reserves
+    const spotPrice = calcSpotPrice(reserveA, reserveB)
+
+    if (spotPrice === 0) {
+      console.debug(
+        `[soroswap] Skipping empty pool ${poolEntry.poolAddress} for ${pair.pairKey}`
+      )
+      return
+    }
+
+    await upsertPricePoints([
+      {
+        assetA: pair.assetA.code,
+        assetB: pair.assetB.code,
+        pairKey: pair.pairKey,
+        source: 'soroswap_amm' as const,
+        poolId: poolEntry.poolAddress,
+        price: spotPrice,
+        baseVolume: 0,
+        counterVolume: 0,
+        ledger: 0,
+        timestamp: new Date(),
+        eventId: `soroswap-${poolEntry.poolAddress}-${Date.now()}`,
+      },
+    ])
+
+    const previousPrice = lastPrice.get(pair.pairKey) ?? spotPrice
+    lastPrice.set(pair.pairKey, spotPrice)
+
+    dispatchPriceUpdate({
+      assetA: pair.assetA.code,
+      assetB: pair.assetB.code,
+      previousPrice,
+      currentPrice: spotPrice,
+    }).catch((err) =>
+      console.error('[soroswap] webhook dispatch error:', err.message)
+    )
+
+    console.log(
+      `[soroswap] Pool ${poolEntry.poolAddress.slice(0, 8)}: price=${spotPrice.toFixed(8)} for ${pair.pairKey}`
+    )
+  } catch (err) {
+    console.error(
+      `[soroswap] ingestPool error for ${poolEntry.poolAddress}:`,
+      (err as Error).message
+    )
+  }
+}
+
+// ── Main per-pair logic ───────────────────────────────────────────────────────
+
+/**
+ * Discover Soroswap pools for a watched pair, then snapshot each pool's price.
+ * Matches pair assets to token list by symbol; filters to watched pairs only.
+ */
+export async function ingestPair(
+  pair: WatchedPair,
+  tokens: SoroswapToken[],
+  factoryAddress: string
+): Promise<void> {
+  const tokenA = tokens.find(
+    (t) => t.symbol.toUpperCase() === pair.assetA.code.toUpperCase()
+  )
+  const tokenB = tokens.find(
+    (t) => t.symbol.toUpperCase() === pair.assetB.code.toUpperCase()
+  )
+
+  if (!tokenA || !tokenB) {
+    console.debug(
+      `[soroswap] No Soroswap token found for pair ${pair.pairKey} — skipping`
+    )
+    return
+  }
+
+  const poolAddresses = await fetchPoolsFromFactory(
+    factoryAddress,
+    tokenA.address,
+    tokenB.address
+  )
+
+  if (!poolAddresses.length) {
+    console.debug(
+      `[soroswap] No pools found for ${pair.pairKey} — skipping`
+    )
+    return
+  }
+
+  await Promise.all(
+    poolAddresses.map((addr) =>
+      ingestPool(
+        { poolAddress: addr, tokenA, tokenB },
+        pair
+      )
+    )
+  )
+}
+
+// ── Ingester loop ─────────────────────────────────────────────────────────────
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+/**
+ * Start the Soroswap AMM ingester. Runs as an infinite polling loop.
+ * Fault-isolated: a crash is caught by the caller (restartIngester in index.ts).
+ */
+export async function startSoroswapIngester(): Promise<void> {
+  const factoryAddress = config.soroswap.factoryAddress
+  const pollInterval = config.soroswap.pollIntervalMs
+
+  console.log(
+    `[soroswap] Starting Soroswap ingester | factory=${factoryAddress} | interval=${pollInterval}ms`
+  )
+
+  while (true) {
+    const pairs = getActivePairs()
+    const tokens = await fetchSoroswapTokenList()
+
+    if (tokens.length === 0) {
+      console.warn('[soroswap] Token list empty — skipping poll cycle')
+    } else {
+      await Promise.all(
+        pairs.map((pair) => ingestPair(pair, tokens, factoryAddress))
+      )
+    }
+
+    await sleep(pollInterval)
+  }
+}


### PR DESCRIPTION


- Add src/ingesters/soroswap.ts with full pool discovery, reserve polling, spot price calculation, and upsertPricePoints integration
- Add SOROSWAP_FACTORY_ADDRESS and SOROSWAP_POLL_INTERVAL_MS to config.ts
- Wire startSoroswapIngester into src/index.ts alongside SDEX and AMM ingesters
- Update .env.example with Soroswap env vars
- Add src/__tests__/soroswapIngester.test.ts with unit tests for spot price calculation, empty-pool guard, and error isolation

## Summary

## Related issue
Closes #48  

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] CI / tooling

## Checklist
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] `npx tsc --noEmit` passes
- [X] `npm run build` passes
- [X] I added / updated tests where relevant
- [X] I updated docs where relevant
