### PR TITLE
Add cross-venue arbitrage sanity test and divergence alert helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -354,29 +354,6 @@
         "prettier": "^2.7.1"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3528,6 +3505,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/alerts/arbitrage.ts
+++ b/src/alerts/arbitrage.ts
@@ -1,0 +1,23 @@
+export interface CrossVenueAlertPayload {
+  sdexPrice: number
+  ammPrice: number
+  diffPct: number
+}
+
+export function checkCrossVenueDivergence(
+  sdexPrice: number,
+  ammPrice: number,
+  threshold: number = 0.05,
+  onAlert: (payload: CrossVenueAlertPayload) => void = () => {}
+): boolean {
+  if (!isFinite(sdexPrice) || !isFinite(ammPrice)) return false
+  if (sdexPrice <= 0 || ammPrice <= 0) return false
+
+  const diff = Math.abs(sdexPrice - ammPrice) / Math.max(sdexPrice, ammPrice)
+  const diffPct = diff
+  if (diffPct > threshold) {
+    onAlert({ sdexPrice, ammPrice, diffPct })
+    return true
+  }
+  return false
+}

--- a/src/alerts/index.ts
+++ b/src/alerts/index.ts
@@ -1,2 +1,3 @@
 export * from './delivery'
 export * from './threshold'
+export * from './arbitrage'

--- a/tests/arbitrage.test.ts
+++ b/tests/arbitrage.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { checkCrossVenueDivergence } from "../src/alerts/arbitrage";
+
+describe("Arbitrage cross-venue sanity test", () => {
+  it("triggers alert when SDEX and AMM differ by >5%", () => {
+    const alert = vi.fn();
+    const sdexPrice = 1.0;
+    const ammPrice = 1.06; // 6% difference
+
+    const fired = checkCrossVenueDivergence(sdexPrice, ammPrice, 0.05, alert);
+
+    expect(fired).toBe(true);
+    expect(alert).toHaveBeenCalledTimes(1);
+    const payload = alert.mock.calls[0][0];
+    expect(payload).toHaveProperty("sdexPrice", sdexPrice);
+    expect(payload).toHaveProperty("ammPrice", ammPrice);
+    expect(payload.diffPct).toBeGreaterThan(0.05);
+  });
+
+  it("does not trigger alert when divergence is <=5%", () => {
+    const alert = vi.fn();
+    const sdexPrice = 1.0;
+    const ammPrice = 1.049; // 4.9% difference
+
+    const fired = checkCrossVenueDivergence(sdexPrice, ammPrice, 0.05, alert);
+
+    expect(fired).toBe(false);
+    expect(alert).not.toHaveBeenCalled();
+  });
+
+  it("ignores invalid or zero prices", () => {
+    const alert = vi.fn();
+    expect(checkCrossVenueDivergence(0, 1.2, 0.05, alert)).toBe(false);
+    expect(checkCrossVenueDivergence(NaN, 1.2, 0.05, alert)).toBe(false);
+    expect(alert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Added a cross-venue arbitrage sanity test that injects divergent SDEX vs AMM prices and verifies the alert path triggers when the difference exceeds 5%.

## Related issue
Closes: #79 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [x] Tests
- [ ] CI / tooling

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] I added / updated tests where relevant
- [ ] I updated docs where relevant
