### PR TITLE
Add price aggregation utility to compute weighted composite price across sources

### DIFF
--- a/src/pricing/aggregate.ts
+++ b/src/pricing/aggregate.ts
@@ -1,0 +1,69 @@
+import { pgPool } from '../db'
+
+/**
+ * Aggregate price for a pair across sources (SDEX, AMM) weighted by volume.
+ * Sources that deviate from the weighted average by more than the provided
+ * threshold are excluded from the final composite price.
+ *
+ * @param pairKey The pair identifier (e.g., "XLM/USDC").
+ * @param deviationThreshold Fractional threshold (e.g., 0.05 for 5%).
+ * @returns Composite price and per‑source breakdown.
+ */
+export async function aggregatePrice(
+  pairKey: string,
+  deviationThreshold: number = 0.05,
+): Promise<{
+  composite: number
+  breakdown: Array<{
+    source: string
+    price: number
+    volume: number
+    excluded: boolean
+    reason?: string
+  }>
+}> {
+  // Fetch VWAP and volume per source for the last hour.
+  const result = await pgPool.query(
+    `SELECT
+       source,
+       COALESCE(SUM(price::numeric * base_volume::numeric), 0) / NULLIF(SUM(base_volume::numeric), 0) AS vwap,
+       SUM(base_volume::numeric) AS volume
+     FROM price_points
+     WHERE pair_key = $1
+       AND timestamp > NOW() - INTERVAL '1 hour'
+     GROUP BY source`,
+    [pairKey]
+  )
+
+  const sources = result.rows.map((row: any) => ({
+    source: row.source as string,
+    price: parseFloat(row.vwap ?? '0'),
+    volume: parseFloat(row.volume ?? '0'),
+    excluded: false,
+    reason: undefined as string | undefined,
+  }))
+
+  // Initial weighted average using all sources.
+  const totalVolume = sources.reduce((sum, s) => sum + s.volume, 0)
+  const initialWeightedAvg = totalVolume === 0 ? 0 : sources.reduce((sum, s) => sum + s.price * s.volume, 0) / totalVolume
+
+  // Determine exclusions based on deviation.
+  for (const s of sources) {
+    if (initialWeightedAvg === 0) {
+      s.excluded = false
+      continue
+    }
+    const deviation = Math.abs(s.price - initialWeightedAvg) / initialWeightedAvg
+    if (deviation > deviationThreshold) {
+      s.excluded = true
+      s.reason = `deviation ${(deviation * 100).toFixed(2)}% exceeds threshold ${(deviationThreshold * 100).toFixed(2)}%`
+    }
+  }
+
+  // Re‑calculate composite using only non‑excluded sources.
+  const included = sources.filter(s => !s.excluded)
+  const includedVolume = included.reduce((sum, s) => sum + s.volume, 0)
+  const composite = includedVolume === 0 ? 0 : included.reduce((sum, s) => sum + s.price * s.volume, 0) / includedVolume
+
+  return { composite, breakdown: sources }
+}


### PR DESCRIPTION
This PR closes #73 
## Summary
Add a price‑aggregation utility (`src/pricing/aggregate.ts`) that:
- Retrieves VWAP and volume data for each source (SDEX, AMM) over the last hour.
- Computes a weighted composite price based on liquidity/volume.
- Excludes any source whose price deviates beyond the configurable threshold, providing a clear reason for exclusion.
- Returns a detailed per‑source breakdown alongside the composite price for use by the `/price/:assetA/:assetB` endpoint.


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] CI / tooling

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] I added / updated tests where relevant
- [x] I updated docs where relevant