### PR TITLE
feat: gate GraphQL endpoint with x402 payment requirement

### DIFF
--- a/src/__tests__/middleware/x402.test.ts
+++ b/src/__tests__/middleware/x402.test.ts
@@ -57,6 +57,7 @@ async function buildApp() {
   app.get('/price/test', async () => ({ ok: true }))
   app.get('/pools/test', async () => ({ ok: true }))
   app.get('/candles/test', async () => ({ ok: true }))
+  app.post('/graphql', async () => ({ ok: true }))
   app.get('/public', async () => ({ ok: true }))
   await app.ready()
   return app
@@ -171,5 +172,45 @@ describe('x402 middleware', () => {
 
     await new Promise(r => setTimeout(r, 20))
     expect(mockSettle).toHaveBeenCalledOnce()
+  })
+
+  it('gates POST requests to /graphql with $0.10 price requirement', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload: { query: '{ test }' },
+    })
+
+    expect(res.statusCode).toBe(402)
+    expect(res.json().accepts[0]).toHaveProperty('price', '$0.10')
+  })
+
+  it('allows POST to /graphql with valid payment header', async () => {
+    mockVerify.mockResolvedValue({ isValid: true })
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload: { query: '{ test }' },
+      headers: { 'x-payment': makePaymentHeader() },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(mockVerify).toHaveBeenCalledOnce()
+  })
+
+  it('does not gate GET requests to /graphql', async () => {
+    const app = await buildApp()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/graphql',
+    })
+
+    expect(res.statusCode).toBe(404)
+    expect(mockVerify).not.toHaveBeenCalled()
   })
 })

--- a/src/middleware/x402.ts
+++ b/src/middleware/x402.ts
@@ -11,6 +11,7 @@ const GATED_ROUTES: Record<string, { price: string; description: string }> = {
   '/price': { price: '$0.10', description: 'Unified SDEX+AMM price with VWAP and best route' },
   '/pools': { price: '$0.05', description: 'AMM liquidity pool reserves and spot prices' },
   '/candles': { price: '$0.05', description: 'OHLCV candle data for trading charts' },
+  '/graphql': { price: '$0.10', description: 'GraphQL queries for price data and market information' },
 }
 
 /**
@@ -36,10 +37,12 @@ async function x402Plugin(app: FastifyInstance) {
   app.log.info('[oracle] x402 payment gating enabled')
 
   app.addHook('preHandler', async (req: FastifyRequest, reply: FastifyReply) => {
-    // Only gate GET requests on matching path prefixes
-    const matchedRoute = Object.keys(GATED_ROUTES).find(prefix =>
-      req.url.startsWith(prefix) && req.method === 'GET'
-    )
+    // Gate GET requests on matching path prefixes, or POST requests to /graphql
+    const matchedRoute = Object.keys(GATED_ROUTES).find(prefix => {
+      const pathMatches = req.url.startsWith(prefix)
+      const methodAllowed = prefix === '/graphql' ? req.method === 'POST' : req.method === 'GET'
+      return pathMatches && methodAllowed
+    })
     if (!matchedRoute) return
 
     const { price, description } = GATED_ROUTES[matchedRoute]


### PR DESCRIPTION
- Add /graphql POST route to GATED_ROUTES with $0.10 price
- Extend x402 middleware to gate POST requests to /graphql
- Ensure GraphQL queries require same payment auth as REST endpoints
- Add comprehensive test coverage for GraphQL gating behavior:
  - Verify 402 response for unauthenticated POST requests
  - Verify 200 response with valid payment header
  - Verify GET requests to /graphql are not gated

Resolves inconsistency noted in README where GraphQL was not protected by x402 payment gating. Now all price data endpoints require payment authorization when ORACLE_PAYMENT_ADDRESS is configured.

## Summary

## Related issue
<!-- Closes #123 -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Tests
- [ ] CI / tooling

## Checklist
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes
- [ ] I added / updated tests where relevant
- [ ] I updated docs where relevant
