### PR TITLE
fix(ws): WebSocket subscription tests and @fastify/websocket v11 fix

### DIFF
--- a/scripts/ws-smoke.ts
+++ b/scripts/ws-smoke.ts
@@ -1,0 +1,78 @@
+import Fastify from 'fastify'
+import WebSocket from 'ws'
+
+async function run() {
+  // Disable x402 payment gating for smoke test runs. Must set before importing server module.
+  process.env.ORACLE_PAYMENT_ADDRESS = ''
+
+  const { registerWebSocket } = await import('../src/api/websocket')
+  const { priceEmitter, PRICE_UPDATE } = await import('../src/events')
+
+  const app = Fastify({ logger: { level: 'info' } })
+  await registerWebSocket(app)
+  await app.listen({ port: 0, host: '127.0.0.1' })
+  // @ts-ignore
+  const addr = app.server.address() as any
+  const port = addr.port
+
+  console.log(`[ws-smoke] Server listening on port ${port}`)
+
+  const before = priceEmitter.listenerCount(PRICE_UPDATE)
+
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+
+  const open = new Promise<void>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error('ws open timeout')), 5000)
+    ws.on('open', () => { clearTimeout(t); resolve() })
+    ws.on('error', (err) => { clearTimeout(t); reject(err) })
+  })
+  await open
+  console.log('[ws-smoke] WebSocket connected')
+
+  const firstMsg = await new Promise<string>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error('no initial message')), 5000)
+    ws.once('message', (data) => { clearTimeout(t); resolve(data.toString()) })
+  })
+  console.log('[ws-smoke] initial message:', firstMsg)
+  const first = JSON.parse(firstMsg)
+  if (first.type !== 'status' && first.type !== 'error') throw new Error('expected status or error message')
+
+  if (priceEmitter.listenerCount(PRICE_UPDATE) !== before + 1) {
+    throw new Error('server did not register price listener')
+  }
+
+  const event = {
+    assetA: 'XLM',
+    assetB: 'USDC',
+    previousPrice: 1.0,
+    currentPrice: 1.2345,
+    timestamp: new Date()
+  }
+
+  const nextMsg = new Promise<string>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error('no price update received')), 5000)
+    ws.once('message', (data) => { clearTimeout(t); resolve(data.toString()) })
+  })
+
+  priceEmitter.emit(PRICE_UPDATE, event)
+  const nextRaw = await nextMsg
+  console.log('[ws-smoke] price message:', nextRaw)
+  const next = JSON.parse(nextRaw)
+  if (next.type !== 'price_update') throw new Error('expected price_update')
+  if (next.currentPrice !== event.currentPrice) throw new Error('price mismatch')
+
+  ws.close()
+  await new Promise<void>((resolve) => ws.on('close', () => resolve()))
+
+  if (priceEmitter.listenerCount(PRICE_UPDATE) !== before) {
+    throw new Error('listener was not cleaned up after close')
+  }
+
+  await app.close()
+  console.log('[ws-smoke] Success')
+}
+
+run().catch(err => {
+  console.error('[ws-smoke] Failed:', err)
+  process.exitCode = 1
+})

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -26,15 +26,15 @@ export async function registerWebSocket(app: FastifyInstance) {
     }
   }
 
-  app.get('/ws', { websocket: true, config: { public: true } }, (connection, req: FastifyRequest) => {
+  // @fastify/websocket v11: handler receives (socket, req) directly — no connection wrapper
+  app.get('/ws', { websocket: true, config: { public: true } }, (socket: any, req: FastifyRequest) => {
     app.log.info('[ws] New connection attempt')
 
-    // x402 Auth
     const paymentHeader = (req.headers['x-payment'] as string) || (req.query as any).payment
 
     const requirements = {
       scheme: 'exact' as const,
-      price: '$0.50', // Premium for real-time streaming
+      price: '$0.50',
       network: NETWORK,
       payTo: PAYMENT_ADDRESS!,
     }
@@ -42,52 +42,47 @@ export async function registerWebSocket(app: FastifyInstance) {
     if (!PAYMENT_ADDRESS || !resourceServer) {
       app.log.warn('[ws] x402 disabled (PAYMENT_ADDRESS missing or x402 init failed)')
     } else if (!paymentHeader) {
-      connection.socket.send(JSON.stringify({
+      socket.send(JSON.stringify({
         type: 'error',
         status: 402,
         message: 'Payment required for real-time streaming',
         requirements
       }))
-      connection.socket.close()
+      socket.close()
       return
     } else {
-      // Verify payment
       verifyPayment(paymentHeader, requirements, resourceServer)
         .then(isValid => {
           if (!isValid) {
-            connection.socket.send(JSON.stringify({ type: 'error', message: 'Invalid payment' }))
-            connection.socket.close()
+            socket.send(JSON.stringify({ type: 'error', message: 'Invalid payment' }))
+            socket.close()
           } else {
-            setupStream(connection, req)
+            setupStream(socket, req)
           }
         })
         .catch(err => {
-          connection.socket.send(JSON.stringify({ type: 'error', message: err.message }))
-          connection.socket.close()
+          socket.send(JSON.stringify({ type: 'error', message: err.message }))
+          socket.close()
         })
       return
     }
 
-    // If x402 is disabled or already passed (shouldn't happen with logic above but for safety)
-    setupStream(connection, req)
+    setupStream(socket, req)
   })
 
-  function setupStream(connection: any, req: FastifyRequest) {
+  function setupStream(socket: any, req: FastifyRequest) {
     app.log.info('[ws] Connection authorized')
-    connection.socket.send(JSON.stringify({ type: 'status', message: 'Streaming active' }))
+    socket.send(JSON.stringify({ type: 'status', message: 'Streaming active' }))
 
     const onPriceUpdate = (event: PriceUpdateEvent) => {
-      if (connection.socket.readyState === 1) { // OPEN
-        connection.socket.send(JSON.stringify({
-          type: 'price_update',
-          ...event
-        }))
+      if (socket.readyState === 1) { // OPEN
+        socket.send(JSON.stringify({ type: 'price_update', ...event }))
       }
     }
 
     priceEmitter.on(PRICE_UPDATE, onPriceUpdate)
 
-    connection.socket.on('close', () => {
+    socket.on('close', () => {
       app.log.info('[ws] Connection closed')
       priceEmitter.off(PRICE_UPDATE, onPriceUpdate)
     })

--- a/tests/integration/ws.test.ts
+++ b/tests/integration/ws.test.ts
@@ -1,0 +1,67 @@
+import { beforeAll, afterAll, describe, it, expect } from 'vitest'
+import Fastify from 'fastify'
+import WebSocket from 'ws'
+
+import { registerWebSocket } from '../../src/api/websocket'
+import { priceEmitter, PRICE_UPDATE } from '../../src/events'
+
+describe('WebSocket subscription full cycle', () => {
+  let app: ReturnType<typeof Fastify>
+  let port: number
+
+  beforeAll(async () => {
+    app = Fastify({ logger: false })
+    await registerWebSocket(app)
+    await app.listen({ port: 0, host: '127.0.0.1' })
+    const address = app.server?.address() as any
+    port = address.port
+  })
+
+  afterAll(async () => {
+    if (app) await app.close()
+  })
+
+  it('connects → subscribes → receives updates → disconnects', async () => {
+    const before = priceEmitter.listenerCount(PRICE_UPDATE)
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+    await new Promise<void>((resolve, reject) => {
+      ws.on('open', () => resolve())
+      ws.on('error', (err) => reject(err))
+    })
+
+    // First message should be streaming status
+    const firstRaw = await new Promise<string>(resolve => ws.once('message', (data) => resolve(data.toString())))
+    const first = JSON.parse(firstRaw)
+    expect(first.type).toBe('status')
+    expect(first.message).toBe('Streaming active')
+
+    // Listener registered on the server
+    expect(priceEmitter.listenerCount(PRICE_UPDATE)).toBe(before + 1)
+
+    // Emit a price update and verify it's received
+    const event = {
+      assetA: 'XLM',
+      assetB: 'USDC',
+      previousPrice: 1.0,
+      currentPrice: 1.2345,
+      timestamp: new Date()
+    }
+
+    const nextRaw = new Promise<string>(resolve => ws.once('message', (data) => resolve(data.toString())))
+    priceEmitter.emit(PRICE_UPDATE, event)
+    const next = JSON.parse(await nextRaw)
+
+    expect(next.type).toBe('price_update')
+    expect(next.assetA).toBe(event.assetA)
+    expect(next.assetB).toBe(event.assetB)
+    expect(next.currentPrice).toBe(event.currentPrice)
+    expect(new Date(next.timestamp).toISOString()).toBe(event.timestamp.toISOString())
+
+    // Close connection and ensure listener cleanup
+    ws.close()
+    await new Promise<void>(resolve => ws.on('close', () => resolve()))
+
+    expect(priceEmitter.listenerCount(PRICE_UPDATE)).toBe(before)
+  })
+})

--- a/tests/integration/ws.test.ts
+++ b/tests/integration/ws.test.ts
@@ -13,8 +13,7 @@ describe('WebSocket subscription full cycle', () => {
     app = Fastify({ logger: false })
     await registerWebSocket(app)
     await app.listen({ port: 0, host: '127.0.0.1' })
-    const address = app.server?.address() as any
-    port = address.port
+    port = (app.server.address() as any).port
   })
 
   afterAll(async () => {
@@ -24,43 +23,61 @@ describe('WebSocket subscription full cycle', () => {
   it('connects → subscribes → receives updates → disconnects', async () => {
     const before = priceEmitter.listenerCount(PRICE_UPDATE)
 
+    const messages: string[] = []
+    const waiters: Array<(msg: string) => void> = []
+
     const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
-    await new Promise<void>((resolve, reject) => {
-      ws.on('open', () => resolve())
-      ws.on('error', (err) => reject(err))
+
+    // Attach message listener before awaiting open to avoid the race where the
+    // server sends the status message synchronously on connect.
+    ws.on('message', (data) => {
+      const msg = data.toString()
+      const waiter = waiters.shift()
+      if (waiter) waiter(msg)
+      else messages.push(msg)
     })
 
-    // First message should be streaming status
-    const firstRaw = await new Promise<string>(resolve => ws.once('message', (data) => resolve(data.toString())))
-    const first = JSON.parse(firstRaw)
+    const nextMessage = () =>
+      new Promise<string>((resolve) => {
+        const buffered = messages.shift()
+        if (buffered !== undefined) resolve(buffered)
+        else waiters.push(resolve)
+      })
+
+    // 1. Connect
+    await new Promise<void>((resolve, reject) => {
+      ws.on('open', () => resolve())
+      ws.on('error', reject)
+    })
+
+    // 2. Receive initial status (may already be buffered)
+    const first = JSON.parse(await nextMessage())
     expect(first.type).toBe('status')
     expect(first.message).toBe('Streaming active')
 
-    // Listener registered on the server
+    // 3. Listener should now be registered server-side
     expect(priceEmitter.listenerCount(PRICE_UPDATE)).toBe(before + 1)
 
-    // Emit a price update and verify it's received
+    // 4. Emit a price update and verify it's received
     const event = {
       assetA: 'XLM',
       assetB: 'USDC',
       previousPrice: 1.0,
       currentPrice: 1.2345,
-      timestamp: new Date()
+      timestamp: new Date(),
     }
-
-    const nextRaw = new Promise<string>(resolve => ws.once('message', (data) => resolve(data.toString())))
     priceEmitter.emit(PRICE_UPDATE, event)
-    const next = JSON.parse(await nextRaw)
 
+    const next = JSON.parse(await nextMessage())
     expect(next.type).toBe('price_update')
     expect(next.assetA).toBe(event.assetA)
     expect(next.assetB).toBe(event.assetB)
     expect(next.currentPrice).toBe(event.currentPrice)
     expect(new Date(next.timestamp).toISOString()).toBe(event.timestamp.toISOString())
 
-    // Close connection and ensure listener cleanup
+    // 5. Disconnect and verify listener cleanup
     ws.close()
-    await new Promise<void>(resolve => ws.on('close', () => resolve()))
+    await new Promise<void>((resolve) => ws.on('close', () => resolve()))
 
     expect(priceEmitter.listenerCount(PRICE_UPDATE)).toBe(before)
   })


### PR DESCRIPTION
## Summary

Closes #77 — adds integration tests for the live-price WebSocket endpoint.

## Root cause

`@fastify/websocket` v11 changed its handler signature: the first argument is now the `WebSocket` socket directly, not a `connection` object. The existing `websocket.ts` used the old `connection.socket` API, so every call to `connection.socket.send()` was a runtime error.

## Changes

**`src/api/websocket.ts`**
- Updated the route handler signature from `(connection, req)` to `(socket, req)`
- Replaced all `connection.socket.*` calls with `socket.*`

**`tests/integration/ws.test.ts`** (new)
- Full cycle test: connect → receive status → emit price update → receive price_update → disconnect
- Verifies server-side listener is registered on connect and cleaned up on disconnect
- Fixes a race condition: `ws` does not buffer messages after `open`, so the message listener is attached before awaiting `open` via a simple queue/waiter pattern

## Test output

```
✓ tests/integration/ws.test.ts > WebSocket subscription full cycle > connects → subscribes → receives updates → disconnects 16ms
```