### PR TITLE
feat: add market depth and slippage estimation endpoint

### DIFF
--- a/src/__tests__/depth.test.ts
+++ b/src/__tests__/depth.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  calculateAMMOutput,
+  calculateAMMPrice,
+  calculateAMMSpotPrice,
+  generateAMMDepthLevels
+} from '../pricing/depth'
+
+describe('Depth and slippage calculations', () => {
+  describe('calculateAMMSpotPrice', () => {
+    it('calculates correct spot price from reserves', () => {
+      expect(calculateAMMSpotPrice(1000, 500)).toBe(0.5)
+      expect(calculateAMMSpotPrice(500, 1000)).toBe(2)
+    })
+
+    it('returns 0 when reserveA is 0', () => {
+      expect(calculateAMMSpotPrice(0, 1000)).toBe(0)
+    })
+  })
+
+  describe('calculateAMMOutput', () => {
+    it('calculates correct output for constant product with fees', () => {
+      const reserveA = 1000
+      const reserveB = 500
+      const amount = 100
+      const feeBp = 30 // 0.3%
+      
+      const output = calculateAMMOutput(reserveA, reserveB, amount, feeBp)
+      
+      expect(output).toBeGreaterThan(0)
+      expect(output).toBeLessThan(50) // Without fees: ~45.45, with fees: less
+    })
+
+    it('handles no fees correctly', () => {
+      const reserveA = 1000
+      const reserveB = 500
+      const amount = 100
+      const feeBp = 0
+      
+      const output = calculateAMMOutput(reserveA, reserveB, amount, feeBp)
+      
+      expect(output).toBeCloseTo(45.4545, 4)
+    })
+  })
+
+  describe('calculateAMMPrice', () => {
+    it('calculates price per unit', () => {
+      const reserveA = 1000
+      const reserveB = 500
+      const amount = 100
+      const feeBp = 30
+      
+      const price = calculateAMMPrice(reserveA, reserveB, amount, feeBp)
+      
+      expect(price).toBeGreaterThan(0)
+    })
+  })
+
+  describe('generateAMMDepthLevels', () => {
+    it('generates asks and bids', () => {
+      const reserveA = 1000
+      const reserveB = 500
+      const feeBp = 30
+      
+      const { asks, bids } = generateAMMDepthLevels(reserveA, reserveB, feeBp)
+      
+      expect(asks.length).toBe(10)
+      expect(bids.length).toBe(10)
+      
+      // Asks (selling A for B) should have decreasing price with increasing size
+      for (let i = 1; i < asks.length; i++) {
+        expect(asks[i].price).toBeLessThan(asks[i-1].price)
+        expect(asks[i].size).toBeGreaterThan(asks[i-1].size)
+      }
+      
+      // Bids (buying A with B) should have increasing price with increasing size
+      for (let i = 1; i < bids.length; i++) {
+        expect(bids[i].price).toBeGreaterThan(bids[i-1].price)
+      }
+    })
+
+    it('accepts custom numLevels and stepSize', () => {
+      const reserveA = 1000
+      const reserveB = 500
+      const feeBp = 30
+      
+      const { asks, bids } = generateAMMDepthLevels(reserveA, reserveB, feeBp, 5, 0.05)
+      
+      expect(asks.length).toBe(5)
+      expect(bids.length).toBe(5)
+    })
+  })
+})

--- a/src/__tests__/schemaValidation.test.ts
+++ b/src/__tests__/schemaValidation.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import Fastify from 'fastify'
 import Ajv from 'ajv'
 
-const { mockQuery, mockGetCachedPrice, mockGetBestRoute, mockGetAggregatedPrice } = vi.hoisted(() => ({
+const { mockQuery, mockGetCachedPrice, mockGetBestRoute, mockGetAggregatedPrice, mockGetDepth } = vi.hoisted(() => ({
   mockQuery: vi.fn(),
   mockGetCachedPrice: vi.fn(),
   mockGetBestRoute: vi.fn(),
   mockGetAggregatedPrice: vi.fn(),
+  mockGetDepth: vi.fn(),
 }))
 
 vi.mock('../db', () => ({
@@ -24,6 +25,10 @@ vi.mock('../aggregator/bestRoute', () => ({
 
 vi.mock('../aggregator/vwap', () => ({
   getAggregatedPrice: mockGetAggregatedPrice,
+}))
+
+vi.mock('../pricing/depth', () => ({
+  getDepth: mockGetDepth,
 }))
 
 vi.mock('../config', () => ({
@@ -66,6 +71,8 @@ function validAggregate() {
     sources: 2,
     confidence: 'high' as const,
     lastTradeAgeSeconds: 10,
+    stale: false,
+    bestRoute: 'SDEX' as const,
   }
 }
 
@@ -74,6 +81,14 @@ describe('REST response schema validation', () => {
     vi.clearAllMocks()
     mockGetCachedPrice.mockResolvedValue(null)
     mockGetBestRoute.mockResolvedValue({ route: 'SDEX' })
+    mockGetDepth.mockResolvedValue({
+      spotPrice: 0.1,
+      executionPrice: 0.099,
+      slippagePct: 1.0,
+      asks: [],
+      bids: [],
+      source: 'AMM',
+    })
   })
 
   it('returns 200 and a body that matches the declared /price schema', async () => {

--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -11,8 +11,10 @@ import {
   routeResponseSchema,
   historyResponseSchema,
   poolsResponseSchema,
+  depthResponseSchema,
   installResponseValidation,
 } from './schemas'
+import { getDepth } from '../pricing/depth'
 
 function makePairKey(a: string, b: string): string {
   return [a, b].sort().join('/')
@@ -159,4 +161,30 @@ export async function registerRESTRoutes(app: FastifyInstance) {
     )
     return { pools: result.rows }
   })
+
+  // GET /price/:assetA/:assetB/depth?amount=1000
+  app.get<{
+    Params: { assetA: string; assetB: string }
+    Querystring: { amount?: string }
+  }>(
+    '/price/:assetA/:assetB/depth',
+    { schema: { response: { 200: depthResponseSchema } } },
+    async (req, reply) => {
+      const { assetA, assetB } = req.params
+      const amount = parseFloat(req.query.amount ?? '1000')
+      const pair = findPair(assetA, assetB)
+      
+      if (!pair) return reply.status(404).send({ error: `Pair ${assetA}/${assetB} not watched` })
+      if (isNaN(amount) || amount <= 0) return reply.status(400).send({ error: 'amount must be a positive number' })
+
+      const depthResult = await getDepth(pair.pairKey, amount)
+      
+      return {
+        assetA: pair.assetA.code,
+        assetB: pair.assetB.code,
+        pairKey: pair.pairKey,
+        ...depthResult
+      }
+    }
+  )
 }

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -177,6 +177,45 @@ export const poolsResponseSchema = {
   },
 } as const
 
+export const depthResponseSchema = {
+  type: 'object',
+  required: ['assetA', 'assetB', 'pairKey', 'spotPrice', 'executionPrice', 'slippagePct', 'asks', 'bids', 'source'],
+  additionalProperties: false,
+  properties: {
+    assetA: { type: 'string' },
+    assetB: { type: 'string' },
+    pairKey: { type: 'string' },
+    spotPrice: { type: 'number' },
+    executionPrice: { type: 'number' },
+    slippagePct: { type: 'number' },
+    asks: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['price', 'size'],
+        additionalProperties: false,
+        properties: {
+          price: { type: 'number' },
+          size: { type: 'number' },
+        },
+      },
+    },
+    bids: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['price', 'size'],
+        additionalProperties: false,
+        properties: {
+          price: { type: 'number' },
+          size: { type: 'number' },
+        },
+      },
+    },
+    source: { type: 'string', enum: ['AMM', 'SDEX', 'BOTH'] },
+  },
+} as const
+
 /**
  * Install response-shape validation on a Fastify instance.
  *

--- a/src/pricing/depth.ts
+++ b/src/pricing/depth.ts
@@ -1,0 +1,114 @@
+import { pgPool } from '../db'
+
+export interface DepthLevel {
+  price: number
+  size: number
+}
+
+export interface DepthResult {
+  spotPrice: number
+  executionPrice: number
+  slippagePct: number
+  asks: DepthLevel[]
+  bids: DepthLevel[]
+  source: 'AMM' | 'SDEX' | 'BOTH'
+}
+
+export function calculateAMMOutput(reserveA: number, reserveB: number, amount: number, feeBp: number): number {
+  const fee = 1 - feeBp / 10000
+  const effectiveInput = amount * fee
+  return (reserveB * effectiveInput) / (reserveA + effectiveInput)
+}
+
+export function calculateAMMPrice(reserveA: number, reserveB: number, amount: number, feeBp: number): number {
+  const output = calculateAMMOutput(reserveA, reserveB, amount, feeBp)
+  return output / amount
+}
+
+export function calculateAMMSpotPrice(reserveA: number, reserveB: number): number {
+  return reserveA > 0 ? reserveB / reserveA : 0
+}
+
+export function generateAMMDepthLevels(
+  reserveA: number,
+  reserveB: number,
+  feeBp: number,
+  numLevels: number = 10,
+  stepSize: number = 0.01
+): { asks: DepthLevel[]; bids: DepthLevel[] } {
+  const asks: DepthLevel[] = []
+  const bids: DepthLevel[] = []
+
+  // Generate asks (selling asset A for B) — price is B per A
+  for (let i = 1; i <= numLevels; i++) {
+    const amountA = reserveA * stepSize * i
+    const price = calculateAMMPrice(reserveA, reserveB, amountA, feeBp)
+    asks.push({ price, size: amountA })
+  }
+
+  // Generate bids (buying asset A with B) — price is A per B, but we want B per A (inverse)
+  for (let i = 1; i <= numLevels; i++) {
+    const amountB = reserveB * stepSize * i
+    const fee = 1 - feeBp / 10000
+    const effectiveInput = amountB * fee
+    const amountA = (reserveA * effectiveInput) / (reserveB + effectiveInput)
+    // Price is amount of A we get per B → but we usually display bids as amount of B per A (inverse)
+    // Wait no: actually for pair A/B, bids are orders to buy A with B, so the price is how much B you pay per A
+    // So price = amountB / amountA
+    const price = amountB / amountA
+    bids.push({ price, size: amountA })
+  }
+
+  return { asks, bids }
+}
+
+export async function getAMMDepth(pairKey: string, amount: number): Promise<DepthResult | null> {
+  const result = await pgPool.query(
+    `SELECT DISTINCT ON (ps.pool_id) ps.reserve_a, ps.reserve_b, ps.fee_bp
+     FROM pool_snapshots ps
+     WHERE ps.pool_id IN (
+       SELECT DISTINCT pool_id FROM price_points
+       WHERE pair_key = $1 AND source = 'AMM' AND pool_id IS NOT NULL
+     )
+     ORDER BY ps.pool_id, ps.timestamp DESC
+     LIMIT 1`,
+    [pairKey]
+  )
+  if (!result.rows[0]) return null
+
+  const { reserve_a, reserve_b, fee_bp } = result.rows[0]
+  const rA = parseFloat(reserve_a)
+  const rB = parseFloat(reserve_b)
+  const feeBp = parseInt(fee_bp)
+
+  const spotPrice = calculateAMMSpotPrice(rA, rB)
+  const executionPrice = calculateAMMPrice(rA, rB, amount, feeBp)
+  const slippagePct = spotPrice > 0 ? Math.abs((executionPrice - spotPrice) / spotPrice * 100) : 0
+  const { asks, bids } = generateAMMDepthLevels(rA, rB, feeBp)
+
+  return {
+    spotPrice,
+    executionPrice,
+    slippagePct,
+    asks,
+    bids,
+    source: 'AMM',
+  }
+}
+
+export async function getDepth(pairKey: string, amount: number): Promise<DepthResult> {
+  const ammDepth = await getAMMDepth(pairKey, amount)
+  
+  if (ammDepth) {
+    return ammDepth
+  }
+
+  return {
+    spotPrice: 0,
+    executionPrice: 0,
+    slippagePct: 0,
+    asks: [],
+    bids: [],
+    source: 'AMM',
+  }
+}


### PR DESCRIPTION
## Summary
successfully built the liquidity depth and slippage estimation endpoint!

## Related issue
Closes #84 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [x] Tests
- [ ] CI / tooling

## Checklist
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] I added / updated tests where relevant
- [ ] I updated docs where relevant
