### PR TITLE
feat(routes): /volumes/:asset cross-venue volume endpoint (#92)

### DIFF
--- a/src/__tests__/volumes.test.ts
+++ b/src/__tests__/volumes.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Fastify from 'fastify'
+
+const { mockQuery } = vi.hoisted(() => ({ mockQuery: vi.fn() }))
+
+vi.mock('../db', () => ({
+  pgPool: { query: mockQuery },
+}))
+
+import { registerVolumeRoutes } from '../routes/volumes'
+
+async function buildApp() {
+  const app = Fastify({ logger: false })
+  await registerVolumeRoutes(app)
+  await app.ready()
+  return app
+}
+
+describe('GET /volumes/:asset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the cross-venue sum and a per-venue breakdown', async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        { source: 'SDEX', volume: '100.5', trade_count: 3 },
+        { source: 'AMM', volume: '49.5', trade_count: 2 },
+      ],
+    })
+
+    const app = await buildApp()
+    const res = await app.inject({ method: 'GET', url: '/volumes/XLM?window=24h' })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.asset).toBe('XLM')
+    expect(body.window).toBe('24h')
+    expect(body.byVenue).toEqual({ SDEX: 100.5, AMM: 49.5 })
+    expect(body.totalVolume).toBeCloseTo(150)
+    expect(body.venues.sort()).toEqual(['AMM', 'SDEX'])
+    expect(body.tradeCount).toBe(5)
+    await app.close()
+  })
+
+  it('defaults to the 24h window', async () => {
+    mockQuery.mockResolvedValue({ rows: [] })
+    const app = await buildApp()
+    const res = await app.inject({ method: 'GET', url: '/volumes/XLM' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().window).toBe('24h')
+    await app.close()
+  })
+
+  it.each(['24h', '7d', '30d'])('supports the %s window', async (window) => {
+    mockQuery.mockResolvedValue({ rows: [] })
+    const app = await buildApp()
+    const res = await app.inject({ method: 'GET', url: `/volumes/XLM?window=${window}` })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().window).toBe(window)
+    // The query receives the asset and a Date cutoff.
+    expect(mockQuery).toHaveBeenCalledWith(expect.any(String), ['XLM', expect.any(Date)])
+    await app.close()
+  })
+
+  it('uses a wider lookback for longer windows', async () => {
+    mockQuery.mockResolvedValue({ rows: [] })
+    const app = await buildApp()
+
+    await app.inject({ method: 'GET', url: '/volumes/XLM?window=24h' })
+    const start24h = (mockQuery.mock.calls[0][1] as [string, Date])[1].getTime()
+    mockQuery.mockClear()
+    await app.inject({ method: 'GET', url: '/volumes/XLM?window=30d' })
+    const start30d = (mockQuery.mock.calls[0][1] as [string, Date])[1].getTime()
+
+    expect(start30d).toBeLessThan(start24h)
+    await app.close()
+  })
+
+  it('rejects an invalid window with 400', async () => {
+    const app = await buildApp()
+    const res = await app.inject({ method: 'GET', url: '/volumes/XLM?window=12h' })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/window must be one of/)
+    await app.close()
+  })
+
+  it('returns zero volume when there are no trades', async () => {
+    mockQuery.mockResolvedValue({ rows: [] })
+    const app = await buildApp()
+    const res = await app.inject({ method: 'GET', url: '/volumes/XLM?window=7d' })
+    const body = res.json()
+    expect(body.totalVolume).toBe(0)
+    expect(body.byVenue).toEqual({})
+    expect(body.tradeCount).toBe(0)
+    await app.close()
+  })
+
+  it('returns 500 when the query fails', async () => {
+    mockQuery.mockRejectedValue(new Error('db down'))
+    const app = await buildApp()
+    const res = await app.inject({ method: 'GET', url: '/volumes/XLM?window=24h' })
+    expect(res.statusCode).toBe(500)
+    expect(res.json().error).toMatch(/Volume aggregation failed/)
+    await app.close()
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { registerWebSocket } from './api/websocket'
 import { registerApiKeyAuth } from './api/auth'
 import { registerAdminRoutes } from './api/admin'
 import { registerPriceRoutes } from './routes/price'
+import { registerVolumeRoutes } from './routes/volumes'
 import { fanOutManager } from './ws/fanout'
 
 import { startSDEXIngester } from './ingesters/sdex'
@@ -110,6 +111,7 @@ async function main() {
   await registerScreenerRoutes(app)
   await registerHistoryRoutes(app)
   await registerPriceRoutes(app)
+  await registerVolumeRoutes(app)
   await registerGraphQL(app)
   await registerWebSocket(app)
 

--- a/src/routes/volumes.ts
+++ b/src/routes/volumes.ts
@@ -1,0 +1,93 @@
+import type { FastifyInstance } from 'fastify'
+import { pgPool } from '../db'
+
+// Supported windows → lookback in hours.
+const WINDOW_HOURS = {
+  '24h': 24,
+  '7d': 24 * 7,
+  '30d': 24 * 30,
+} as const
+
+type VolumeWindow = keyof typeof WINDOW_HOURS
+
+const WINDOWS = Object.keys(WINDOW_HOURS) as VolumeWindow[]
+
+/**
+ * Register the aggregated cross-venue volume endpoint.
+ *
+ * GET /volumes/:asset?window=24h|7d|30d
+ *
+ * Sums traded volume for `asset` across every pair it appears in and across all
+ * venues (SDEX, AMM, …) over the requested window. Volume is measured in the
+ * asset's own units: when it is the base asset of a pair we count `base_volume`,
+ * when it is the counter asset we count `counter_volume`. The response breaks the
+ * total down per venue and also returns the cross-venue sum.
+ */
+export async function registerVolumeRoutes(app: FastifyInstance) {
+  app.get<{
+    Params: { asset: string }
+    Querystring: { window?: string }
+  }>('/volumes/:asset', async (req, reply) => {
+    const { asset } = req.params
+    const window = req.query.window ?? '24h'
+
+    if (!(window in WINDOW_HOURS)) {
+      return reply
+        .status(400)
+        .send({ error: `window must be one of: ${WINDOWS.join(', ')}` })
+    }
+
+    const hours = WINDOW_HOURS[window as VolumeWindow]
+    const endTime = new Date()
+    const startTime = new Date(endTime.getTime() - hours * 60 * 60 * 1000)
+
+    try {
+      // Per-venue volume for the asset, summed over the window. The asset's volume
+      // is base_volume when it's asset_a and counter_volume when it's asset_b.
+      const { rows } = await pgPool.query(
+        `SELECT source,
+                SUM(
+                  CASE
+                    WHEN asset_a = $1 THEN base_volume
+                    WHEN asset_b = $1 THEN counter_volume
+                    ELSE 0
+                  END
+                )::numeric AS volume,
+                COUNT(*)::int AS trade_count
+           FROM price_points
+          WHERE (asset_a = $1 OR asset_b = $1)
+            AND timestamp >= $2
+          GROUP BY source`,
+        [asset, startTime],
+      )
+
+      const byVenue: Record<string, number> = {}
+      let totalVolume = 0
+      let tradeCount = 0
+
+      for (const row of rows) {
+        const volume = parseFloat(row.volume) || 0
+        byVenue[row.source] = volume
+        totalVolume += volume
+        tradeCount += Number(row.trade_count) || 0
+      }
+
+      return {
+        asset,
+        window,
+        startTime: startTime.toISOString(),
+        endTime: endTime.toISOString(),
+        // Cross-venue sum.
+        totalVolume,
+        // Per-venue breakdown that the total is summed from.
+        byVenue,
+        venues: Object.keys(byVenue),
+        tradeCount,
+      }
+    } catch (err) {
+      return reply
+        .status(500)
+        .send({ error: `Volume aggregation failed: ${(err as Error).message}` })
+    }
+  })
+}


### PR DESCRIPTION
## Summary

Implements **#92 — `/volumes` endpoint**: `GET /volumes/:asset?window=24h|7d|30d` returning aggregated cross-venue volume for an asset.

## What it does
Sums `price_points` volume for the asset across **every pair it appears in** and **every venue** (`source` — SDEX, AMM, …) within the window. Volume is measured in the asset's own units: `base_volume` when it's the base asset of a pair, `counter_volume` when it's the counter. The response gives a per-venue breakdown plus the cross-venue total:

```json
{
  "asset": "XLM",
  "window": "24h",
  "startTime": "…", "endTime": "…",
  "totalVolume": 150.0,
  "byVenue": { "SDEX": 100.5, "AMM": 49.5 },
  "venues": ["SDEX", "AMM"],
  "tradeCount": 5
}
```

Mirrors the existing `routes/price.ts` style; SQL is parameterized (asset + a Date cutoff). Invalid `window` → 400; query failure → 500. Registered in `index.ts`.

## Acceptance criteria
- ✅ **Three windows** — `24h` / `7d` / `30d` (default `24h`; anything else → 400).
- ✅ **Cross-venue sum** — `byVenue` per `source` + the summed `totalVolume`.

## Verification
- `prisma generate` + `tsc --noEmit` — clean.
- `vitest run src/__tests__/volumes.test.ts` — **9/9 passing** (cross-venue sum + per-venue breakdown, default window, all three windows, wider lookback for longer windows, invalid-window 400, empty result, 500).

> **Note:** the full suite has 3 failures that are **pre-existing and unrelated to this change** — `schemaValidation.test.ts` (a `/price` test) and `aggregator.property.test.ts` (price-aggregator property test) don't import anything in this PR, and `e2e.test.ts` needs Docker. `main`'s CI is also currently not green (CI run pending approval + a failing load test). This PR's own files (route + test) are green and typecheck-clean.

Closes #92
