### PR TITLE
feat: Aquarius AMM ingester, Reflector oracle comparison, Portfolio NAV example, Python SDK

### DIFF
--- a/clients/python/lens_client/__init__.py
+++ b/clients/python/lens_client/__init__.py
@@ -1,0 +1,10 @@
+from .client import LensClient
+from .models import PriceResponse, RouteResponse, CandleResponse, OracleComparison
+
+__all__ = [
+    "LensClient",
+    "PriceResponse",
+    "RouteResponse",
+    "CandleResponse",
+    "OracleComparison",
+]

--- a/clients/python/lens_client/client.py
+++ b/clients/python/lens_client/client.py
@@ -1,0 +1,85 @@
+import json
+import urllib.request
+import urllib.error
+from typing import Optional
+from .models import PriceResponse, RouteResponse, CandleResponse, OracleComparison
+
+
+class LensClient:
+    """Minimal HTTP client for the Lens price indexer API.
+
+    No third-party dependencies — uses only the Python standard library.
+    """
+
+    def __init__(self, base_url: str, timeout: int = 10):
+        self.base_url = base_url.rstrip('/')
+        self.timeout = timeout
+
+    def _get(self, path: str) -> dict:
+        url = f"{self.base_url}{path}"
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            return json.loads(resp.read().decode())
+
+    def get_price(self, asset_a: str, asset_b: str) -> Optional[PriceResponse]:
+        """Return the latest aggregated price for a trading pair."""
+        try:
+            data = self._get(f"/price/{asset_a}/{asset_b}")
+            return PriceResponse(
+                asset_a=data['assetA'],
+                asset_b=data['assetB'],
+                pair_key=data['pairKey'],
+                price=float(data['price']),
+                source=data.get('source', ''),
+                timestamp=data.get('timestamp', ''),
+            )
+        except (urllib.error.HTTPError, KeyError):
+            return None
+
+    def get_route(self, from_asset: str, to_asset: str, amount: float) -> Optional[RouteResponse]:
+        """Return the best swap route between two assets."""
+        try:
+            data = self._get(f"/route/{from_asset}/{to_asset}?amount={amount}")
+            return RouteResponse(
+                path=data.get('path', []),
+                input_asset=data['inputAsset'],
+                output_asset=data['outputAsset'],
+                estimated_output=float(data['estimatedOutput']),
+            )
+        except (urllib.error.HTTPError, KeyError):
+            return None
+
+    def get_candles(self, asset_a: str, asset_b: str, interval: str = '1h', limit: int = 24) -> list:
+        """Return OHLCV candles for a pair."""
+        try:
+            data = self._get(f"/candles/{asset_a}/{asset_b}?interval={interval}&limit={limit}")
+            candles = data if isinstance(data, list) else data.get('candles', [])
+            return [
+                CandleResponse(
+                    pair_key=c.get('pairKey', ''),
+                    open=float(c['open']),
+                    high=float(c['high']),
+                    low=float(c['low']),
+                    close=float(c['close']),
+                    volume=float(c.get('volume', 0)),
+                    timestamp=c.get('timestamp', ''),
+                )
+                for c in candles
+            ]
+        except (urllib.error.HTTPError, KeyError):
+            return []
+
+    def compare_oracle(self, asset: str) -> Optional[OracleComparison]:
+        """Compare Lens price vs Reflector oracle for an asset."""
+        try:
+            data = self._get(f"/compare/{asset}")
+            return OracleComparison(
+                asset=data['asset'],
+                lens=data.get('lens'),
+                reflector=data.get('reflector'),
+                deviation_pct=data.get('deviationPct'),
+                status=data.get('status', 'unknown'),
+                fetched_at=data.get('fetchedAt', ''),
+            )
+        except urllib.error.HTTPError:
+            return None

--- a/clients/python/lens_client/models.py
+++ b/clients/python/lens_client/models.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class PriceResponse:
+    asset_a: str
+    asset_b: str
+    pair_key: str
+    price: float
+    source: str
+    timestamp: str
+
+
+@dataclass
+class RouteResponse:
+    path: list
+    input_asset: str
+    output_asset: str
+    estimated_output: float
+
+
+@dataclass
+class CandleResponse:
+    pair_key: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    timestamp: str
+
+
+@dataclass
+class OracleComparison:
+    asset: str
+    lens: Optional[float]
+    reflector: Optional[float]
+    deviation_pct: Optional[float]
+    status: str
+    fetched_at: str

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="lens-py",
+    version="0.1.0",
+    description="Python client for the Lens Stellar price indexer API",
+    packages=find_packages(),
+    python_requires=">=3.9",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+    ],
+)

--- a/examples/portfolio-nav/package.json
+++ b/examples/portfolio-nav/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "lens-portfolio-nav",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3003",
+    "build": "next build",
+    "start": "next start -p 3003"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/portfolio-nav/pages/index.tsx
+++ b/examples/portfolio-nav/pages/index.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+
+interface AssetBalance {
+  asset_code: string
+  asset_issuer: string | null
+  balance: string
+}
+
+interface NavRow {
+  asset: string
+  balance: number
+  price: number | null
+  value: number | null
+}
+
+export default function PortfolioNav() {
+  const [address, setAddress] = useState('')
+  const [rows, setRows] = useState<NavRow[]>([])
+  const [totalNav, setTotalNav] = useState<number | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const LENS_URL = process.env.NEXT_PUBLIC_LENS_URL ?? 'http://localhost:3000'
+  const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL ?? 'https://horizon.stellar.org'
+
+  async function fetchNav() {
+    if (!address.trim()) return
+    setLoading(true)
+    setError(null)
+    setRows([])
+    setTotalNav(null)
+
+    try {
+      const horizonResp = await fetch(`${HORIZON_URL}/accounts/${address.trim()}`)
+      if (!horizonResp.ok) throw new Error('Account not found on Horizon')
+      const account = await horizonResp.json()
+
+      const balances: AssetBalance[] = (account.balances ?? []).filter(
+        (b: any) => parseFloat(b.balance) > 0
+      ).map((b: any) => ({
+        asset_code: b.asset_type === 'native' ? 'XLM' : b.asset_code,
+        asset_issuer: b.asset_type === 'native' ? null : b.asset_issuer,
+        balance: b.balance,
+      }))
+
+      const navRows: NavRow[] = await Promise.all(
+        balances.map(async (b) => {
+          const bal = parseFloat(b.balance)
+          if (b.asset_code === 'XLM') {
+            // Fetch XLM/USDC price from Lens
+            try {
+              const priceResp = await fetch(`${LENS_URL}/price/XLM/USDC`)
+              if (priceResp.ok) {
+                const data = await priceResp.json()
+                const price = parseFloat(data.price)
+                return { asset: 'XLM', balance: bal, price, value: bal * price }
+              }
+            } catch {}
+            return { asset: 'XLM', balance: bal, price: null, value: null }
+          }
+
+          try {
+            const priceResp = await fetch(`${LENS_URL}/price/${b.asset_code}/USDC`)
+            if (priceResp.ok) {
+              const data = await priceResp.json()
+              const price = parseFloat(data.price)
+              return { asset: b.asset_code, balance: bal, price, value: bal * price }
+            }
+          } catch {}
+          return { asset: b.asset_code, balance: bal, price: null, value: null }
+        })
+      )
+
+      setRows(navRows)
+      const total = navRows.reduce((sum, r) => sum + (r.value ?? 0), 0)
+      setTotalNav(total)
+    } catch (e: any) {
+      setError(e.message ?? 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main style={{ fontFamily: 'monospace', maxWidth: 700, margin: '40px auto', padding: '0 16px' }}>
+      <h1>Stellar Portfolio NAV</h1>
+      <p style={{ color: '#555' }}>Enter a Stellar address to compute its net asset value using Lens prices.</p>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 24 }}>
+        <input
+          style={{ flex: 1, padding: '8px 12px', fontFamily: 'monospace', fontSize: 13 }}
+          placeholder="G... Stellar address"
+          value={address}
+          onChange={e => setAddress(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && fetchNav()}
+        />
+        <button
+          onClick={fetchNav}
+          disabled={loading}
+          style={{ padding: '8px 16px', cursor: loading ? 'wait' : 'pointer' }}
+        >
+          {loading ? 'Loading…' : 'Fetch NAV'}
+        </button>
+      </div>
+
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+
+      {rows.length > 0 && (
+        <>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #ccc', textAlign: 'left' }}>
+                <th style={{ padding: '6px 8px' }}>Asset</th>
+                <th style={{ padding: '6px 8px', textAlign: 'right' }}>Balance</th>
+                <th style={{ padding: '6px 8px', textAlign: 'right' }}>Price (USDC)</th>
+                <th style={{ padding: '6px 8px', textAlign: 'right' }}>Value (USDC)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(r => (
+                <tr key={r.asset} style={{ borderBottom: '1px solid #eee' }}>
+                  <td style={{ padding: '6px 8px' }}>{r.asset}</td>
+                  <td style={{ padding: '6px 8px', textAlign: 'right' }}>{r.balance.toFixed(7)}</td>
+                  <td style={{ padding: '6px 8px', textAlign: 'right' }}>
+                    {r.price !== null ? r.price.toFixed(6) : '—'}
+                  </td>
+                  <td style={{ padding: '6px 8px', textAlign: 'right' }}>
+                    {r.value !== null ? r.value.toFixed(2) : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p style={{ marginTop: 16, fontSize: 14 }}>
+            <strong>Total NAV:</strong>{' '}
+            {totalNav !== null ? `$${totalNav.toFixed(2)} USDC` : 'Partial (some prices unavailable)'}
+          </p>
+        </>
+      )}
+    </main>
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,14 @@ import { registerAdminRoutes } from './api/admin'
 import { registerUsageRoutes } from './api/usage'
 import { registerPriceRoutes } from './routes/price'
 import { registerVolumeRoutes } from './routes/volumes'
+import { registerOracleRoutes } from './routes/oracle'
 import { fanOutManager } from './ws/fanout'
 
 import { startSDEXIngester } from './ingesters/sdex'
 import { startAMMIngester } from './ingesters/amm'
 import { startSoroswapIngester } from './ingesters/soroswap'
 import { startSnapshotIngester } from './ingesters/snapshot'
+import { startAquariusIngester } from './ingest/venues/aquarius'
 import { createAggregateQueue, startAggregateWorker, scheduleAggregateRefresh } from './jobs/aggregateRefresh'
 import { createSnapshotRetentionQueue, startSnapshotRetentionWorker, scheduleSnapshotRetention } from './jobs/snapshotRetention'
 import { loadPersistedPairs, getActivePairs } from './pairsRegistry'
@@ -114,6 +116,7 @@ async function main() {
   await registerHistoryRoutes(app)
   await registerPriceRoutes(app)
   await registerVolumeRoutes(app)
+  await registerOracleRoutes(app)
   await registerGraphQL(app)
   await registerWebSocket(app)
 
@@ -169,6 +172,7 @@ async function main() {
   restartIngester('AMM', startAMMIngester)
   restartIngester('Soroswap', startSoroswapIngester)
   restartIngester('Snapshot', startSnapshotIngester)
+  restartIngester('Aquarius', startAquariusIngester)
 
   console.log(`[lens] Watching ${getActivePairs().length} pairs: ${getActivePairs().map(p => p.pairKey).join(', ')}`)
 }

--- a/src/ingest/oracles/reflector.ts
+++ b/src/ingest/oracles/reflector.ts
@@ -1,0 +1,102 @@
+/**
+ * Reflector Oracle Adapter
+ *
+ * Polls Reflector on-chain oracle contract prices via Soroban RPC simulation
+ * and provides price data for the /compare/:asset comparison endpoint.
+ *
+ * Issue: #104
+ */
+
+import {
+  Contract,
+  rpc as SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  Keypair,
+  scValToNative,
+  nativeToScVal,
+  Account,
+} from '@stellar/stellar-sdk'
+import { config } from '../../config'
+
+// Reflector oracle mainnet contract address
+const REFLECTOR_CONTRACT_ID =
+  process.env.REFLECTOR_CONTRACT_ID ??
+  'CCYXZMNHFXHKF3YEX4VJJ5TH3YHCVZIBPNBGM7C4PJIMCIMNNWDOQYA'
+
+// Ephemeral fee payer — simulation only, no real funds needed
+const FEE_PAYER = Keypair.random()
+
+let _rpc: SorobanRpc.Server | null = null
+function getRpc(): SorobanRpc.Server {
+  _rpc ??= new SorobanRpc.Server(config.rpc.url, { allowHttp: true })
+  return _rpc
+}
+
+export interface ReflectorPrice {
+  asset: string
+  price: number
+  timestamp: number
+}
+
+/**
+ * Fetch the latest price for a given asset code from the Reflector oracle.
+ * Returns null when the contract is unreachable or the asset is unknown.
+ */
+export async function fetchReflectorPrice(assetCode: string): Promise<ReflectorPrice | null> {
+  try {
+    const rpc = getRpc()
+    const contract = new Contract(REFLECTOR_CONTRACT_ID)
+    const account = new Account(FEE_PAYER.publicKey(), '0')
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: config.network.passphrase,
+    })
+      .addOperation(
+        contract.call('lastprice', nativeToScVal(assetCode, { type: 'symbol' }))
+      )
+      .setTimeout(30)
+      .build()
+
+    const result = await rpc.simulateTransaction(tx)
+    if (!SorobanRpc.Api.isSimulationSuccess(result)) return null
+
+    const raw = scValToNative((result as any).result?.retval) as {
+      price?: bigint
+      timestamp?: bigint
+    } | null
+
+    if (!raw || raw.price === undefined) return null
+
+    // Reflector uses 14 decimal places of precision
+    const price = Number(raw.price) / 1e14
+
+    return {
+      asset: assetCode.toUpperCase(),
+      price,
+      timestamp: Number(raw.timestamp ?? 0),
+    }
+  } catch {
+    return null
+  }
+}
+
+// In-memory cache (60 s TTL) to avoid hammering RPC on every comparison request
+const _cache = new Map<string, { price: number; fetchedAt: number }>()
+const CACHE_TTL_MS = 60_000
+
+export async function getCachedReflectorPrice(asset: string): Promise<number | null> {
+  const key = asset.toUpperCase()
+  const entry = _cache.get(key)
+  if (entry && Date.now() - entry.fetchedAt < CACHE_TTL_MS) {
+    return entry.price
+  }
+  const fresh = await fetchReflectorPrice(key)
+  if (fresh) {
+    _cache.set(key, { price: fresh.price, fetchedAt: Date.now() })
+    return fresh.price
+  }
+  return null
+}

--- a/src/ingest/venues/aquarius.ts
+++ b/src/ingest/venues/aquarius.ts
@@ -1,0 +1,108 @@
+/**
+ * Aquarius AMM Venue Adapter
+ *
+ * Indexes Aquarius liquidity pool (Stellar classic) reserves via the
+ * Aquarius AMM API, calculates spot prices from constant-product invariants,
+ * and stores them in price_points with source = 'aquarius_amm'.
+ *
+ * Issue: #103
+ */
+
+import { config } from '../../config'
+import { getActivePairs } from '../../pairsRegistry'
+import { upsertPricePoints } from '../../db'
+import { dispatchPriceUpdate } from '../../webhookDispatcher'
+import type { WatchedPair } from '../../types'
+
+const AQUARIUS_AMM_API = 'https://amm.aquarius.network/api/v1/pools/'
+
+const lastPrice = new Map<string, number>()
+
+interface AquariusPool {
+  pool_hash: string
+  reserves: string[]
+  total_shares: string
+}
+
+interface AquariusListResponse {
+  results?: AquariusPool[]
+}
+
+export async function fetchAquariusPools(pair: WatchedPair): Promise<AquariusPool[]> {
+  try {
+    const assetAStr = pair.assetA.issuer
+      ? `${pair.assetA.code}:${pair.assetA.issuer}`
+      : 'native'
+    const assetBStr = pair.assetB.issuer
+      ? `${pair.assetB.code}:${pair.assetB.issuer}`
+      : 'native'
+
+    const params = new URLSearchParams()
+    params.append('assets[]', assetAStr)
+    params.append('assets[]', assetBStr)
+
+    const res = await fetch(`${AQUARIUS_AMM_API}?${params.toString()}`)
+    if (!res.ok) return []
+    const data = await res.json() as AquariusListResponse
+    return data.results ?? []
+  } catch (err) {
+    console.error(`[aquarius] Failed to fetch pools for ${pair.pairKey}:`, (err as Error).message)
+    return []
+  }
+}
+
+export async function ingestAquariusPair(pair: WatchedPair): Promise<void> {
+  const pools = await fetchAquariusPools(pair)
+  if (pools.length === 0) return
+
+  const points = pools.flatMap(pool => {
+    const [r0Str, r1Str] = pool.reserves
+    if (!r0Str || !r1Str) return []
+
+    const r0 = parseFloat(r0Str)
+    const r1 = parseFloat(r1Str)
+    if (r0 <= 0 || r1 <= 0) return []
+
+    return [{
+      assetA: pair.assetA.code,
+      assetB: pair.assetB.code,
+      pairKey: pair.pairKey,
+      source: 'aquarius_amm' as const,
+      poolId: pool.pool_hash,
+      price: r1 / r0,
+      baseVolume: 0,
+      counterVolume: 0,
+      ledger: 0,
+      timestamp: new Date(),
+    }]
+  })
+
+  if (points.length === 0) return
+
+  await upsertPricePoints(points as any)
+
+  const latest = points[points.length - 1]
+  const previousPrice = lastPrice.get(pair.pairKey) ?? latest.price
+  lastPrice.set(pair.pairKey, latest.price)
+
+  dispatchPriceUpdate({
+    assetA: pair.assetA.code,
+    assetB: pair.assetB.code,
+    previousPrice,
+    currentPrice: latest.price,
+  }).catch(err => console.error('[aquarius] webhook dispatch error:', (err as Error).message))
+}
+
+async function sleep(ms: number) {
+  return new Promise(r => setTimeout(r, ms))
+}
+
+export async function startAquariusIngester(): Promise<void> {
+  console.log(`[aquarius] Starting Aquarius AMM ingester for ${getActivePairs().length} pairs`)
+  while (true) {
+    for (const pair of getActivePairs()) {
+      await ingestAquariusPair(pair)
+    }
+    await sleep(config.indexer.pollIntervalMs)
+  }
+}

--- a/src/routes/oracle.ts
+++ b/src/routes/oracle.ts
@@ -1,0 +1,54 @@
+import type { FastifyInstance } from 'fastify'
+import { getCachedReflectorPrice } from '../ingest/oracles/reflector'
+import { pgPool } from '../db'
+
+export async function registerOracleRoutes(app: FastifyInstance) {
+  app.get<{ Params: { asset: string } }>('/compare/:asset', async (req, reply) => {
+    const { asset } = req.params
+    const assetCode = asset.toUpperCase()
+
+    const [reflectorPrice, dbResult] = await Promise.all([
+      getCachedReflectorPrice(assetCode),
+      pgPool.query(
+        `SELECT
+           pair_key,
+           COALESCE(
+             SUM(price::numeric * base_volume::numeric), 0
+           ) / NULLIF(SUM(base_volume::numeric), 0) AS vwap
+         FROM price_points
+         WHERE (asset_a = $1 OR asset_b = $1)
+           AND timestamp > NOW() - INTERVAL '5 minutes'
+         GROUP BY pair_key
+         LIMIT 1`,
+        [assetCode]
+      ),
+    ])
+
+    const lensPrice = dbResult.rows[0] ? parseFloat(dbResult.rows[0].vwap) : null
+
+    if (reflectorPrice === null && lensPrice === null) {
+      return reply.status(404).send({ error: `No price data found for asset ${assetCode}` })
+    }
+
+    const deviation =
+      reflectorPrice !== null && lensPrice !== null
+        ? Math.abs(reflectorPrice - lensPrice) / reflectorPrice
+        : null
+
+    return {
+      asset: assetCode,
+      lens: lensPrice,
+      reflector: reflectorPrice,
+      deviationPct: deviation !== null ? parseFloat((deviation * 100).toFixed(4)) : null,
+      status:
+        deviation !== null
+          ? deviation < 0.01
+            ? 'aligned'
+            : deviation < 0.05
+            ? 'minor_deviation'
+            : 'major_deviation'
+          : 'partial',
+      fetchedAt: new Date().toISOString(),
+    }
+  })
+}


### PR DESCRIPTION
Closes #103

---

Closes #105

---

Closes #104

---

Closes #106

---

## Summary

- **Aquarius AMM venue (#103):**  — polls Aquarius AMM API for pool reserves, computes spot prices from constant-product invariants, stores results in  with . Wired into the server as a fault-isolated restartable ingester.

- **Reflector oracle comparison (#104):**  — fetches on-chain prices via Soroban RPC simulation against the Reflector oracle contract (60 s in-memory cache).  exposes  which returns Lens VWAP vs Reflector price alongside deviation percentage and alignment status ( /  / ).

- **Portfolio NAV example (#105):**  — Next.js 14 app that accepts a Stellar address, fetches balances from Horizon, resolves prices from Lens, and displays a NAV table with per-asset and total USDC value.

- **Python SDK (#106):**  — zero-dependency Python 3.9+ client with typed dataclasses (, , , ) and  methods: , , , . Packaged as  via .

## Test plan

- [ ]  resolves pairs and calls  /  per pool
- [ ]  returns , , , and  fields
- [ ]  returns 404
- [ ] Portfolio NAV page loads balances for a live Stellar address and shows value column
- [ ]  then  returns a 