### PR TITLE
feat: CEX adapter interface and mock implementation

### DIFF
--- a/src/__tests__/cexIngester.test.ts
+++ b/src/__tests__/cexIngester.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  registerCexAdapter,
+  getCexAdapter,
+  getAllCexAdapters,
+  type CexAdapter,
+} from '../ingest/cex/index'
+import { MockCexAdapter } from '../ingest/cex/mock'
+
+describe('CexAdapter interface', () => {
+  it('MockCexAdapter satisfies CexAdapter shape', () => {
+    const adapter: CexAdapter = new MockCexAdapter()
+    expect(typeof adapter.name).toBe('string')
+    expect(typeof adapter.fetchTicker).toBe('function')
+    expect(typeof adapter.fetchOrderBook).toBe('function')
+  })
+})
+
+describe('MockCexAdapter.fetchTicker', () => {
+  let adapter: MockCexAdapter
+
+  beforeEach(() => {
+    adapter = new MockCexAdapter('mock')
+  })
+
+  it('returns a ticker with correct pair string', async () => {
+    const ticker = await adapter.fetchTicker('XLM', 'USDC')
+    expect(ticker).not.toBeNull()
+    expect(ticker!.pair).toBe('XLM/USDC')
+  })
+
+  it('returns default seed values', async () => {
+    const ticker = await adapter.fetchTicker('XLM', 'USDC')
+    expect(ticker!.bid).toBeCloseTo(0.098)
+    expect(ticker!.ask).toBeCloseTo(0.102)
+    expect(ticker!.last).toBeCloseTo(0.100)
+  })
+
+  it('respects per-pair seed overrides', async () => {
+    adapter.setSeed('XLM/USDC', { last: 0.42, bid: 0.41, ask: 0.43 })
+    const ticker = await adapter.fetchTicker('XLM', 'USDC')
+    expect(ticker!.last).toBeCloseTo(0.42)
+    expect(ticker!.bid).toBeCloseTo(0.41)
+    expect(ticker!.ask).toBeCloseTo(0.43)
+  })
+
+  it('returns null for unknown pairs', async () => {
+    adapter.markUnknown('BTC/USD')
+    const ticker = await adapter.fetchTicker('BTC', 'USD')
+    expect(ticker).toBeNull()
+  })
+
+  it('normalises pair identifiers to uppercase', async () => {
+    const ticker = await adapter.fetchTicker('xlm', 'usdc')
+    expect(ticker!.pair).toBe('XLM/USDC')
+  })
+
+  it('ticker includes a timestamp', async () => {
+    const before = Date.now()
+    const ticker = await adapter.fetchTicker('XLM', 'USDC')
+    expect(ticker!.timestamp.getTime()).toBeGreaterThanOrEqual(before)
+  })
+})
+
+describe('MockCexAdapter.fetchOrderBook', () => {
+  let adapter: MockCexAdapter
+
+  beforeEach(() => {
+    adapter = new MockCexAdapter('mock')
+  })
+
+  it('returns bids and asks arrays', async () => {
+    const book = await adapter.fetchOrderBook('XLM', 'USDC')
+    expect(book).not.toBeNull()
+    expect(Array.isArray(book!.bids)).toBe(true)
+    expect(Array.isArray(book!.asks)).toBe(true)
+  })
+
+  it('respects depth parameter', async () => {
+    const book = await adapter.fetchOrderBook('XLM', 'USDC', 5)
+    expect(book!.bids).toHaveLength(5)
+    expect(book!.asks).toHaveLength(5)
+  })
+
+  it('bids are below asks (no crossed book)', async () => {
+    const book = await adapter.fetchOrderBook('XLM', 'USDC')
+    const topBid = book!.bids[0].price
+    const topAsk = book!.asks[0].price
+    expect(topBid).toBeLessThan(topAsk)
+  })
+
+  it('returns null for unknown pairs', async () => {
+    adapter.markUnknown('ETH/USD')
+    const book = await adapter.fetchOrderBook('ETH', 'USD')
+    expect(book).toBeNull()
+  })
+})
+
+describe('adapter registry', () => {
+  it('registerCexAdapter + getCexAdapter round-trip', () => {
+    const adapter = new MockCexAdapter('test-exchange')
+    registerCexAdapter(adapter)
+    expect(getCexAdapter('test-exchange')).toBe(adapter)
+  })
+
+  it('getCexAdapter returns undefined for unregistered name', () => {
+    expect(getCexAdapter('nonexistent-exchange')).toBeUndefined()
+  })
+
+  it('getAllCexAdapters includes registered adapters', () => {
+    const adapter = new MockCexAdapter('exchange-a')
+    registerCexAdapter(adapter)
+    const all = getAllCexAdapters()
+    expect(all.some(a => a.name === 'exchange-a')).toBe(true)
+  })
+})

--- a/src/ingest/cex/index.ts
+++ b/src/ingest/cex/index.ts
@@ -1,0 +1,84 @@
+/**
+ * CEX Adapter Interface
+ *
+ * Defines the contract every centralized-exchange adapter must satisfy.
+ * Concrete adapters (Coinbase, Binance, Kraken, …) implement CexAdapter and
+ * are registered via createCexAdapter so callers stay exchange-agnostic.
+ *
+ * Issue: #99
+ */
+
+/** Best bid/ask + last-trade snapshot for a single trading pair. */
+export interface CexTicker {
+  /** Exchange-normalized pair identifier, e.g. "XLM/USDC". */
+  pair: string
+  bid: number
+  ask: number
+  /** Price of the most recent trade. */
+  last: number
+  /** 24 h base-asset volume. */
+  baseVolume: number
+  /** 24 h quote-asset volume. */
+  quoteVolume: number
+  timestamp: Date
+}
+
+/** Single resting order in the order book. */
+export interface CexOrderBookLevel {
+  price: number
+  quantity: number
+}
+
+/** Aggregated order book snapshot. */
+export interface CexOrderBook {
+  pair: string
+  bids: CexOrderBookLevel[]
+  asks: CexOrderBookLevel[]
+  timestamp: Date
+}
+
+/**
+ * Every CEX adapter must implement this interface.
+ *
+ * Adapters are stateless fetch wrappers — they must not cache or store data
+ * themselves; caching is the caller's responsibility.
+ */
+export interface CexAdapter {
+  /** Human-readable exchange identifier used in logs and metrics labels. */
+  readonly name: string
+
+  /**
+   * Fetch the latest ticker for a trading pair.
+   * Returns null when the pair is unknown or the exchange is unreachable.
+   */
+  fetchTicker(base: string, quote: string): Promise<CexTicker | null>
+
+  /**
+   * Fetch an order book snapshot.
+   * Optional — adapters that do not expose an order book may omit this method.
+   *
+   * @param depth Maximum number of levels on each side (default 20).
+   */
+  fetchOrderBook?(base: string, quote: string, depth?: number): Promise<CexOrderBook | null>
+}
+
+/**
+ * Registry of all registered adapters, keyed by name.
+ * Populated via registerCexAdapter; consumed via getCexAdapter / getAllCexAdapters.
+ */
+const _registry = new Map<string, CexAdapter>()
+
+/** Register a CEX adapter so it can be retrieved by name. */
+export function registerCexAdapter(adapter: CexAdapter): void {
+  _registry.set(adapter.name, adapter)
+}
+
+/** Retrieve a registered adapter by exchange name, or undefined if not found. */
+export function getCexAdapter(name: string): CexAdapter | undefined {
+  return _registry.get(name)
+}
+
+/** Return every registered adapter. */
+export function getAllCexAdapters(): CexAdapter[] {
+  return [..._registry.values()]
+}

--- a/src/ingest/cex/mock.ts
+++ b/src/ingest/cex/mock.ts
@@ -1,0 +1,91 @@
+/**
+ * Mock CEX Adapter
+ *
+ * In-memory implementation of CexAdapter for unit tests and local development.
+ * Returns deterministic, configurable data — no HTTP calls are made.
+ *
+ * Issue: #99
+ */
+
+import type { CexAdapter, CexOrderBook, CexTicker } from './index'
+
+export interface MockTickerSeed {
+  bid: number
+  ask: number
+  last: number
+  baseVolume: number
+  quoteVolume: number
+}
+
+const DEFAULT_SEED: MockTickerSeed = {
+  bid: 0.098,
+  ask: 0.102,
+  last: 0.100,
+  baseVolume: 1_000_000,
+  quoteVolume: 100_000,
+}
+
+/**
+ * MockCexAdapter satisfies CexAdapter with fully controllable responses.
+ *
+ * Seed data can be overridden per-pair so tests can exercise edge cases
+ * (stale prices, missing pairs, order book depth limits) without touching
+ * real exchange APIs.
+ */
+export class MockCexAdapter implements CexAdapter {
+  readonly name: string
+
+  private readonly seeds = new Map<string, MockTickerSeed>()
+  private readonly unknownPairs = new Set<string>()
+
+  constructor(name = 'mock') {
+    this.name = name
+  }
+
+  /** Override the seed data for a specific pair key (e.g. "XLM/USDC"). */
+  setSeed(pair: string, seed: Partial<MockTickerSeed>): void {
+    this.seeds.set(pair, { ...DEFAULT_SEED, ...seed })
+  }
+
+  /** Mark a pair as unknown so fetchTicker returns null for it. */
+  markUnknown(pair: string): void {
+    this.unknownPairs.add(pair)
+  }
+
+  async fetchTicker(base: string, quote: string): Promise<CexTicker | null> {
+    const pair = `${base.toUpperCase()}/${quote.toUpperCase()}`
+    if (this.unknownPairs.has(pair)) return null
+
+    const seed = this.seeds.get(pair) ?? DEFAULT_SEED
+    return {
+      pair,
+      bid: seed.bid,
+      ask: seed.ask,
+      last: seed.last,
+      baseVolume: seed.baseVolume,
+      quoteVolume: seed.quoteVolume,
+      timestamp: new Date(),
+    }
+  }
+
+  async fetchOrderBook(base: string, quote: string, depth = 20): Promise<CexOrderBook | null> {
+    const pair = `${base.toUpperCase()}/${quote.toUpperCase()}`
+    if (this.unknownPairs.has(pair)) return null
+
+    const seed = this.seeds.get(pair) ?? DEFAULT_SEED
+    const mid = (seed.bid + seed.ask) / 2
+
+    const bids = Array.from({ length: depth }, (_, i) => ({
+      price: parseFloat((seed.bid - i * 0.001).toFixed(6)),
+      quantity: parseFloat(((i + 1) * 1000).toFixed(2)),
+    }))
+
+    const asks = Array.from({ length: depth }, (_, i) => ({
+      price: parseFloat((seed.ask + i * 0.001).toFixed(6)),
+      quantity: parseFloat(((i + 1) * 1000).toFixed(2)),
+    }))
+
+    void mid
+    return { pair, bids, asks, timestamp: new Date() }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/ingest/cex/index.ts` — `CexAdapter` interface with `fetchTicker`, optional `fetchOrderBook`, and a lightweight adapter registry (`registerCexAdapter` / `getCexAdapter` / `getAllCexAdapters`)
- Adds `src/ingest/cex/mock.ts` — `MockCexAdapter` class: deterministic, zero-HTTP implementation of `CexAdapter` for unit tests and local development; supports per-pair seed overrides and unknown-pair simulation
- Adds `src/__tests__/cexIngester.test.ts` — 14 unit tests covering ticker fields, order-book depth limiting, crossed-book invariant, case normalisation, null returns for unknown pairs, and registry round-trips

## Changes

| File | Change |
|---|---|
| `src/ingest/cex/index.ts` | New — `CexAdapter`, `CexTicker`, `CexOrderBook`, `CexOrderBookLevel` interfaces + registry helpers |
| `src/ingest/cex/mock.ts` | New — `MockCexAdapter` concrete implementation |
| `src/__tests__/cexIngester.test.ts` | New — 14 vitest tests |

## Verification

```
npx vitest run src/__tests__/cexIngester.test.ts
Test Files  1 passed (1)
     Tests  14 passed (14)
```

All 14 new tests pass. Pre-existing suite failures (docker compose unavailable, one missing module path in x402-quota.test.ts, two property-test timeouts) are unrelated to this PR.

closes #99