### PR TITLE
feat: add /basket endpoint for weighted multi-asset basket pricing

### DIFF
--- a/src/__tests__/basket.test.ts
+++ b/src/__tests__/basket.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Fastify from 'fastify'
+
+const { mockQuery } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+}))
+
+vi.mock('../db', () => ({
+  pgPool: { query: mockQuery },
+}))
+
+import { registerBasketRoutes } from '../routes/basket'
+
+async function buildApp() {
+  const app = Fastify({ logger: false })
+  await registerBasketRoutes(app)
+  await app.ready()
+  return app
+}
+
+describe('GET /basket', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns weighted basket price with normalized weights', async () => {
+    mockQuery.mockImplementation(async (_sql: string, params: string[]) => {
+      const asset = params[0]
+      if (asset === 'USDC') return { rows: [{ vwap: '1.0' }] }
+      if (asset === 'XLM') return { rows: [{ vwap: '0.1' }] }
+      return { rows: [{ vwap: null }] }
+    })
+
+    const app = await buildApp()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/basket?asset=USDC&weight=1&asset=XLM&weight=1',
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.basketPrice).toBeCloseTo(0.55, 5)
+    expect(body.weightSum).toBeCloseTo(1.0, 5)
+    expect(body.components).toHaveLength(2)
+    expect(body.components[0].asset).toBe('USDC')
+    expect(body.components[0].weight).toBeCloseTo(0.5, 5)
+    expect(body.components[1].asset).toBe('XLM')
+    expect(body.components[1].weight).toBeCloseTo(0.5, 5)
+    expect(body.computedAt).toBeDefined()
+  })
+
+  it('normalizes unequal weights to sum to 1.0', async () => {
+    mockQuery.mockImplementation(async (_sql: string, params: string[]) => {
+      const asset = params[0]
+      if (asset === 'USDC') return { rows: [{ vwap: '1.0' }] }
+      if (asset === 'EURC') return { rows: [{ vwap: '1.1' }] }
+      return { rows: [{ vwap: null }] }
+    })
+
+    const app = await buildApp()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/basket?asset=USDC&weight=3&asset=EURC&weight=1',
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.weightSum).toBeCloseTo(1.0, 5)
+    // USDC weight = 0.75, EURC weight = 0.25
+    // basketPrice = 0.75*1.0 + 0.25*1.1 = 0.75 + 0.275 = 1.025
+    expect(body.basketPrice).toBeCloseTo(1.025, 5)
+    expect(body.components[0].weight).toBeCloseTo(0.75, 5)
+    expect(body.components[1].weight).toBeCloseTo(0.25, 5)
+  })
+
+  it('returns 400 when no assets provided', async () => {
+    const app = await buildApp()
+    const res = await app.inject({ method: 'GET', url: '/basket' })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/asset/)
+  })
+
+  it('returns 400 when only one asset provided', async () => {
+    const app = await buildApp()
+    const res = await app.inject({ method: 'GET', url: '/basket?asset=USDC&weight=1' })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/2 assets/)
+  })
+
+  it('returns 400 when asset and weight counts do not match', async () => {
+    const app = await buildApp()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/basket?asset=USDC&asset=XLM&weight=1',
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/must match/)
+  })
+
+  it('returns 400 when a weight is not a positive number', async () => {
+    const app = await buildApp()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/basket?asset=USDC&weight=0&asset=XLM&weight=1',
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatch(/positive/)
+  })
+
+  it('returns 404 when an asset has no price data', async () => {
+    mockQuery.mockImplementation(async (_sql: string, params: string[]) => {
+      const asset = params[0]
+      if (asset === 'USDC') return { rows: [{ vwap: '1.0' }] }
+      return { rows: [{ vwap: null }] }
+    })
+
+    const app = await buildApp()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/basket?asset=USDC&weight=1&asset=UNKNOWN&weight=1',
+    })
+    expect(res.statusCode).toBe(404)
+    expect(res.json().error).toMatch(/UNKNOWN/)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { registerUsageRoutes } from './api/usage'
 import { registerPriceRoutes } from './routes/price'
 import { registerVolumeRoutes } from './routes/volumes'
 import { registerOracleRoutes } from './routes/oracle'
+import { registerBasketRoutes } from './routes/basket'
 import { fanOutManager } from './ws/fanout'
 
 import { startSDEXIngester } from './ingesters/sdex'
@@ -117,6 +118,7 @@ async function main() {
   await registerPriceRoutes(app)
   await registerVolumeRoutes(app)
   await registerOracleRoutes(app)
+  await registerBasketRoutes(app)
   await registerGraphQL(app)
   await registerWebSocket(app)
 

--- a/src/routes/basket.ts
+++ b/src/routes/basket.ts
@@ -1,0 +1,81 @@
+import type { FastifyInstance } from 'fastify'
+import { pgPool } from '../db'
+
+async function fetchAssetVWAP(asset: string): Promise<number | null> {
+  const result = await pgPool.query(
+    `SELECT
+       COALESCE(SUM(price::numeric * base_volume::numeric), 0)
+       / NULLIF(SUM(base_volume::numeric), 0) AS vwap
+     FROM price_points
+     WHERE (asset_a = $1 OR asset_b = $1)
+       AND timestamp > NOW() - INTERVAL '5 minutes'`,
+    [asset.toUpperCase()]
+  )
+  const vwap = result.rows[0]?.vwap
+  if (vwap === null || vwap === undefined) return null
+  return parseFloat(vwap)
+}
+
+export async function registerBasketRoutes(app: FastifyInstance) {
+  app.get<{
+    Querystring: { asset?: string | string[]; weight?: string | string[] }
+  }>('/basket', async (req, reply) => {
+    const rawAssets = req.query.asset
+    const rawWeights = req.query.weight
+
+    const assets: string[] = rawAssets
+      ? Array.isArray(rawAssets) ? rawAssets : [rawAssets]
+      : []
+    const weightStrings: string[] = rawWeights
+      ? Array.isArray(rawWeights) ? rawWeights : [rawWeights]
+      : []
+
+    if (assets.length === 0) {
+      return reply.status(400).send({ error: 'At least one asset is required' })
+    }
+    if (assets.length < 2) {
+      return reply.status(400).send({ error: 'Basket requires at least 2 assets' })
+    }
+    if (assets.length !== weightStrings.length) {
+      return reply.status(400).send({ error: 'Number of assets and weights must match' })
+    }
+
+    const rawWeightValues = weightStrings.map(w => parseFloat(w))
+    if (rawWeightValues.some(w => isNaN(w) || w <= 0)) {
+      return reply.status(400).send({ error: 'All weights must be positive numbers' })
+    }
+
+    const weightSum = rawWeightValues.reduce((a, b) => a + b, 0)
+    const normalizedWeights = rawWeightValues.map(w => w / weightSum)
+
+    const prices = await Promise.all(assets.map(a => fetchAssetVWAP(a)))
+
+    const components = assets.map((asset, i) => ({
+      asset: asset.toUpperCase(),
+      price: prices[i],
+      weight: normalizedWeights[i],
+    }))
+
+    const missingAssets = components.filter(c => c.price === null).map(c => c.asset)
+    if (missingAssets.length > 0) {
+      return reply.status(404).send({ error: `No price data found for: ${missingAssets.join(', ')}` })
+    }
+
+    const basketPrice = components.reduce(
+      (sum, c) => sum + c.weight * (c.price as number),
+      0
+    )
+
+    return {
+      basketPrice,
+      components: components.map(c => ({
+        asset: c.asset,
+        price: c.price as number,
+        weight: parseFloat(c.weight.toFixed(8)),
+        contribution: parseFloat((c.weight * (c.price as number)).toFixed(8)),
+      })),
+      weightSum: parseFloat(normalizedWeights.reduce((a, b) => a + b, 0).toFixed(8)),
+      computedAt: new Date().toISOString(),
+    }
+  })
+}


### PR DESCRIPTION
Closes #97

## Summary

- Adds `GET /basket?asset=...&weight=...` accepting repeated query params for multi-asset baskets
- Normalizes supplied weights to sum to 1.0 before computing the basket price, regardless of raw input
- Fetches the 5-minute VWAP per asset from `price_points` (same pattern as the oracle comparison route)
- Returns a full breakdown per component (asset, price, normalized weight, weighted contribution)
- Validates: minimum 2 assets, matching asset/weight array lengths, all weights positive, and price data availability

## New files

- `src/routes/basket.ts`: route handler
- `src/__tests__/basket.test.ts`: unit tests covering happy path, weight normalization, and all validation/error branches

## Test plan

- [x] Equal weights produce a 50/50 split and correct basket price
- [x] Unequal raw weights (e.g., 3:1) normalize to 0.75/0.25 and basket price matches
- [x] Single asset returns 400
- [x] Mismatched asset/weight counts return 400
- [x] Zero or negative weight returns 400
- [x] Asset with no recent price data returns 404